### PR TITLE
feat: v0.2.3 — Invidious streaming, Events overhaul, build fix

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,15 +4,32 @@ import tailwindcss from '@tailwindcss/vite'
 import { cloudflare } from "@cloudflare/vite-plugin"
 import pkg from './package.json' with { type: 'json' }
 
+// Stub plugin for optional dependencies that don't exist in the Cloudflare
+// Workers runtime (e.g. @opentelemetry/api imported by better-auth).
+// Using `external` would leave the import unresolved inside the Worker bundle
+// and cause a validation error at deploy time.
+function stubPlugin(moduleId: string) {
+  const resolvedId = `\0stub:${moduleId}`
+  return {
+    name: `stub:${moduleId}`,
+    resolveId(id: string) {
+      if (id === moduleId) return resolvedId
+    },
+    load(id: string) {
+      if (id === resolvedId) return 'export default {}; export const context = {};'
+    },
+  }
+}
+
 export default defineConfig({
-  plugins: [react(), tailwindcss(), cloudflare()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    cloudflare(),
+    stubPlugin('@opentelemetry/api'),
+  ],
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
     __TURNSTILE_SITE_KEY__: JSON.stringify(process.env.TURNSTILE_SITE_KEY || ''),
-  },
-  build: {
-    rollupOptions: {
-      external: ['@opentelemetry/api'],
-    },
   },
 })


### PR DESCRIPTION
## What's in this release

### v0.2.3
- Sets now stream directly from YouTube — no more uploading audio files
- Hover the progress bar to see a video thumbnail preview at that timestamp
- Event pages redesigned: Mixcloud-style banner, artist lineup, genre breakdown, stats
- Events now support separate logo and cover photo uploads
- Year badges on events throughout the UI
- Set detail sidebar: event card merged with metadata card
- Set grid cards now show the event name

### Build fix
- Stub `@opentelemetry/api` at build time to prevent Cloudflare Worker validation error (`No such module "assets/@opentelemetry/api"`) introduced by the switch from `@vitejs/plugin-react-swc` to `@vitejs/plugin-react`