### PR TITLE
Release v0.3.4-alpha: Song likes, security fixes, theater mode improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Here's the full rewritten changelog for Zephyron. I made every entry shorter, used simple everyday words, and focused on what it means for you as a user — like faster listening or easier navigation. [keepachangelog](https://keepachangelog.com/en/1.1.0/)
 
+## [Unreleased]
+
+### New
+- Theater mode: storyboard thumbnail preview on progress bar hover, with detection chapter markers.
+- Theater mode: Now Playing overlay shows concurrent tracks (w/) with cover art, title, and artist.
+- Theater mode: Up Next notification shows a stacked cover art and `+x` badge when the next slot has simultaneous tracks, plus a `w/ Track A, Track B` line.
+- Fullscreen player: storyboard thumbnail preview and detection markers on both progress bars (theater and standard).
+
+### Improved
+- Player bar: volume slider is always visible (no longer hover-only); play/pause button is properly centered.
+- Player bar: progress bar is taller and higher contrast, easier to see at low playback progress.
+- Player bar hides completely in theater mode — theater controls overlay takes over.
+- Theater mode progress bar matches the standard fullscreen design (5 px, same track color).
+- Theater mode controls overlay uses a drop shadow gradient instead of a backdrop blur.
+- Now Playing overlay no longer shifts right when the tracklist panel is open.
+- Theater mode animations rewritten with spring easing curves and motion blur — smoother entry, flash, and exit throughout.
+
+### Fixed
+- Play/pause button in player bar is now correctly centered relative to the other controls.
+- Now Playing overlay no longer disappears for a moment after the track-change flash animation ends.
+
 ## [0.3.3-alpha] - 2026-04-03
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Here's the full rewritten changelog for Zephyron. I made every entry shorter, used simple everyday words, and focused on what it means for you as a user — like faster listening or easier navigation. [keepachangelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased]
+## [0.3.4-alpha] - 2026-04-03
 
 ### New
 - Theater mode: storyboard thumbnail preview on progress bar hover, with detection chapter markers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,6 @@ Accent scale: `--h2` (light) through `--h4` (dark)
 
 ### Tech Stack
 React 19, Vite 7, Tailwind CSS 4 (`@theme` + CSS custom properties), Zustand 5, Cloudflare Workers + D1 + R2, Better Auth, custom UI primitives (no external component library).
+
+### Package manager
+Remember to always use bun for package management to ensure consistency across the team. Run `bun install` to install dependencies and `bun run <script>` for running scripts defined in package.json. Avoid using npm or yarn to prevent potential issues with lockfiles and node_modules structure.

--- a/bun.lock
+++ b/bun.lock
@@ -8,11 +8,9 @@
         "@better-auth/api-key": "^1.5.6",
         "@opentelemetry/api": "^1.9.1",
         "better-auth": "^1.5.6",
-        "checkout": "actions/checkout",
-        "file-type": "^22.0.0",
         "kysely-d1": "^0.4.0",
         "nanoid": "^5.1.7",
-        "node-vibrant": "^4.0.4",
+        "node-vibrant": "3.1.6",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-icons": "^5.6.0",
@@ -43,19 +41,10 @@
       },
     },
   },
+  "overrides": {
+    "defu": "6.1.6",
+  },
   "packages": {
-    "@actions/core": ["@actions/core@1.11.1", "", { "dependencies": { "@actions/exec": "^1.1.1", "@actions/http-client": "^2.0.1" } }, "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A=="],
-
-    "@actions/exec": ["@actions/exec@1.1.1", "", { "dependencies": { "@actions/io": "^1.0.1" } }, "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w=="],
-
-    "@actions/github": ["@actions/github@6.0.1", "", { "dependencies": { "@actions/http-client": "^2.2.0", "@octokit/core": "^5.0.1", "@octokit/plugin-paginate-rest": "^9.2.2", "@octokit/plugin-rest-endpoint-methods": "^10.4.0", "@octokit/request": "^8.4.1", "@octokit/request-error": "^5.1.1", "undici": "^5.28.5" } }, "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw=="],
-
-    "@actions/http-client": ["@actions/http-client@2.2.3", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^5.25.4" } }, "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA=="],
-
-    "@actions/io": ["@actions/io@1.1.3", "", {}, "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="],
-
-    "@actions/tool-cache": ["@actions/tool-cache@2.0.2", "", { "dependencies": { "@actions/core": "^1.11.1", "@actions/exec": "^1.0.0", "@actions/http-client": "^2.0.1", "@actions/io": "^1.1.1", "semver": "^6.1.0" } }, "sha512-fBhNNOWxuoLxztQebpOaWu6WeVmuwa77Z+DxIZ1B+OYvGkGQon6kTVg6Z32Cb13WCuw0szqonK+hh03mJV7Z6w=="],
-
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
@@ -133,8 +122,6 @@
     "@better-auth/utils": ["@better-auth/utils@0.3.1", "", {}, "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg=="],
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
-
-    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.0", "", { "dependencies": { "@changesets/config": "^3.1.3", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ=="],
 
@@ -266,8 +253,6 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.1", "", { "dependencies": { "@eslint/core": "^1.1.1", "levn": "^0.4.1" } }, "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ=="],
 
-    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
-
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
@@ -340,25 +325,25 @@
 
     "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
 
-    "@jimp/bmp": ["@jimp/bmp@0.22.12", "", { "dependencies": { "@jimp/utils": "^0.22.12", "bmp-js": "^0.1.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-aeI64HD0npropd+AR76MCcvvRaa+Qck6loCOS03CkkxGHN5/r336qTM5HPUdHKMDOGzqknuVPA8+kK1t03z12g=="],
+    "@jimp/bmp": ["@jimp/bmp@0.16.13", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.16.13", "bmp-js": "^0.1.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-9edAxu7N2FX7vzkdl5Jo1BbACfycUtBQX+XBMcHA2bk62P8R0otgkHg798frgAk/WxQIzwxqOH6wMiCwrlAzdQ=="],
 
-    "@jimp/core": ["@jimp/core@0.22.12", "", { "dependencies": { "@jimp/utils": "^0.22.12", "any-base": "^1.1.0", "buffer": "^5.2.0", "exif-parser": "^0.1.12", "file-type": "^16.5.4", "isomorphic-fetch": "^3.0.0", "pixelmatch": "^4.0.2", "tinycolor2": "^1.6.0" } }, "sha512-l0RR0dOPyzMKfjUW1uebzueFEDtCOj9fN6pyTYWWOM/VS4BciXQ1VVrJs8pO3kycGYZxncRKhCoygbNr8eEZQA=="],
+    "@jimp/core": ["@jimp/core@0.16.13", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.16.13", "any-base": "^1.1.0", "buffer": "^5.2.0", "exif-parser": "^0.1.12", "file-type": "^16.5.4", "load-bmfont": "^1.3.1", "mkdirp": "^0.5.1", "phin": "^2.9.1", "pixelmatch": "^4.0.2", "tinycolor2": "^1.4.1" } }, "sha512-qXpA1tzTnlkTku9yqtuRtS/wVntvE6f3m3GNxdTdtmc+O+Wcg9Xo2ABPMh7Nc0AHbMKzwvwgB2JnjZmlmJEObg=="],
 
-    "@jimp/custom": ["@jimp/custom@0.22.12", "", { "dependencies": { "@jimp/core": "^0.22.12" } }, "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q=="],
+    "@jimp/custom": ["@jimp/custom@0.16.13", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/core": "^0.16.13" } }, "sha512-LTATglVUPGkPf15zX1wTMlZ0+AU7cGEGF6ekVF1crA8eHUWsGjrYTB+Ht4E3HTrCok8weQG+K01rJndCp/l4XA=="],
 
-    "@jimp/gif": ["@jimp/gif@0.22.12", "", { "dependencies": { "@jimp/utils": "^0.22.12", "gifwrap": "^0.10.1", "omggif": "^1.0.9" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-y6BFTJgch9mbor2H234VSjd9iwAhaNf/t3US5qpYIs0TSbAvM02Fbc28IaDETj9+4YB4676sz4RcN/zwhfu1pg=="],
+    "@jimp/gif": ["@jimp/gif@0.16.13", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.16.13", "gifwrap": "^0.9.2", "omggif": "^1.0.9" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-yFAMZGv3o+YcjXilMWWwS/bv1iSqykFahFMSO169uVMtfQVfa90kt4/kDwrXNR6Q9i6VHpFiGZMlF2UnHClBvg=="],
 
-    "@jimp/jpeg": ["@jimp/jpeg@0.22.12", "", { "dependencies": { "@jimp/utils": "^0.22.12", "jpeg-js": "^0.4.4" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-Rq26XC/uQWaQKyb/5lksCTCxXhtY01NJeBN+dQv5yNYedN0i7iYu+fXEoRsfaJ8xZzjoANH8sns7rVP4GE7d/Q=="],
+    "@jimp/jpeg": ["@jimp/jpeg@0.16.13", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.16.13", "jpeg-js": "^0.4.2" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-BJHlDxzTlCqP2ThqP8J0eDrbBfod7npWCbJAcfkKqdQuFk0zBPaZ6KKaQKyKxmWJ87Z6ohANZoMKEbtvrwz1AA=="],
 
-    "@jimp/plugin-resize": ["@jimp/plugin-resize@0.22.12", "", { "dependencies": { "@jimp/utils": "^0.22.12" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg=="],
+    "@jimp/plugin-resize": ["@jimp/plugin-resize@0.16.13", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.16.13" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-qoqtN8LDknm3fJm9nuPygJv30O3vGhSBD2TxrsCnhtOsxKAqVPJtFVdGd/qVuZ8nqQANQmTlfqTiK9mVWQ7MiQ=="],
 
-    "@jimp/png": ["@jimp/png@0.22.12", "", { "dependencies": { "@jimp/utils": "^0.22.12", "pngjs": "^6.0.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-Mrp6dr3UTn+aLK8ty/dSKELz+Otdz1v4aAXzV5q53UDD2rbB5joKVJ/ChY310B+eRzNxIovbUF1KVrUsYdE8Hg=="],
+    "@jimp/png": ["@jimp/png@0.16.13", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.16.13", "pngjs": "^3.3.3" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-8cGqINvbWJf1G0Her9zbq9I80roEX0A+U45xFby3tDWfzn+Zz8XKDF1Nv9VUwVx0N3zpcG1RPs9hfheG4Cq2kg=="],
 
-    "@jimp/tiff": ["@jimp/tiff@0.22.12", "", { "dependencies": { "utif2": "^4.0.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-E1LtMh4RyJsoCAfAkBRVSYyZDTtLq9p9LUiiYP0vPtXyxX4BiYBUYihTLSBlCQg5nF2e4OpQg7SPrLdJ66u7jg=="],
+    "@jimp/tiff": ["@jimp/tiff@0.16.13", "", { "dependencies": { "@babel/runtime": "^7.7.2", "utif": "^2.0.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-oJY8d9u95SwW00VPHuCNxPap6Q1+E/xM5QThb9Hu+P6EGuu6lIeLaNBMmFZyblwFbwrH+WBOZlvIzDhi4Dm/6Q=="],
 
-    "@jimp/types": ["@jimp/types@0.22.12", "", { "dependencies": { "@jimp/bmp": "^0.22.12", "@jimp/gif": "^0.22.12", "@jimp/jpeg": "^0.22.12", "@jimp/png": "^0.22.12", "@jimp/tiff": "^0.22.12", "timm": "^1.6.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-wwKYzRdElE1MBXFREvCto5s699izFHNVvALUv79GXNbsOVqlwlOxlWJ8DuyOGIXoLP4JW/m30YyuTtfUJgMRMA=="],
+    "@jimp/types": ["@jimp/types@0.16.13", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/bmp": "^0.16.13", "@jimp/gif": "^0.16.13", "@jimp/jpeg": "^0.16.13", "@jimp/png": "^0.16.13", "@jimp/tiff": "^0.16.13", "timm": "^1.6.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-mC0yVNUobFDjoYLg4hoUwzMKgNlxynzwt3cDXzumGvRJ7Kb8qQGOWJQjQFo5OxmGExqzPphkirdbBF88RVLBCg=="],
 
-    "@jimp/utils": ["@jimp/utils@0.22.12", "", { "dependencies": { "regenerator-runtime": "^0.13.3" } }, "sha512-yJ5cWUknGnilBq97ZXOyOS0HhsHOyAyjHwYfHxGbSyMTohgQI6sVyE8KPgDwH8HHW/nMKXk8TrSwAE71zt716Q=="],
+    "@jimp/utils": ["@jimp/utils@0.16.13", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-VyCpkZzFTHXtKgVO35iKN0sYR10psGpV6SkcSeV4oF7eSYlR8Bl6aQLCzVeFjvESF7mxTmIiI3/XrMobVrtxDA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -391,26 +376,6 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
-
-    "@octokit/auth-token": ["@octokit/auth-token@4.0.0", "", {}, "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="],
-
-    "@octokit/core": ["@octokit/core@5.2.2", "", { "dependencies": { "@octokit/auth-token": "^4.0.0", "@octokit/graphql": "^7.1.0", "@octokit/request": "^8.4.1", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.0.0", "before-after-hook": "^2.2.0", "universal-user-agent": "^6.0.0" } }, "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg=="],
-
-    "@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
-
-    "@octokit/graphql": ["@octokit/graphql@7.1.1", "", { "dependencies": { "@octokit/request": "^8.4.1", "@octokit/types": "^13.0.0", "universal-user-agent": "^6.0.0" } }, "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g=="],
-
-    "@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
-
-    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@9.2.2", "", { "dependencies": { "@octokit/types": "^12.6.0" }, "peerDependencies": { "@octokit/core": "5" } }, "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ=="],
-
-    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@10.4.1", "", { "dependencies": { "@octokit/types": "^12.6.0" }, "peerDependencies": { "@octokit/core": "5" } }, "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg=="],
-
-    "@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
-
-    "@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
-
-    "@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
 
     "@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
@@ -502,8 +467,6 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
 
-    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
-
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
@@ -515,6 +478,8 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/lodash": ["@types/lodash@4.17.24", "", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
@@ -545,28 +510,6 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.57.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.57.2", "@typescript-eslint/types": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw=="],
-
-    "@vibrant/color": ["@vibrant/color@4.0.4", "", {}, "sha512-Fq2tAszz4QOPWfHZ+KuEAchXUD8i594BM2fOJt8dI/fvYbiVoBycBF/BlNH6F4IWBubxXoPqD4JmmAHvFYbNew=="],
-
-    "@vibrant/core": ["@vibrant/core@4.0.4", "", { "dependencies": { "@vibrant/color": "^4.0.4", "@vibrant/generator": "^4.0.4", "@vibrant/image": "^4.0.4", "@vibrant/quantizer": "^4.0.4", "@vibrant/worker": "^4.0.4" } }, "sha512-yZ0XSpW2biKyaJPpBC31AVYgn7NseKSO2q3KNMmDrkL2qC6TEWsBMnSQ28n0m///chZELXpQLx1CCOsWg5pj8w=="],
-
-    "@vibrant/generator": ["@vibrant/generator@4.0.4", "", { "dependencies": { "@vibrant/color": "^4.0.4", "@vibrant/types": "^4.0.4" } }, "sha512-rwq8PnlpKdch4YqaA1FAwdm71gKE2cMrUsbu72TqRFGa8rpP1roaZlQCVXIIwElXVc3r9axZyAcqyTLaMjhrTg=="],
-
-    "@vibrant/generator-default": ["@vibrant/generator-default@4.0.4", "", { "dependencies": { "@vibrant/color": "^4.0.4", "@vibrant/generator": "^4.0.4" } }, "sha512-QeVDeH2dz9lityvJCb84Ml4hlBTElwCpU7SVpiDFBh6gPoCLnzcb1H9G4NgG3hOlAPyrBM+Ivq1Pg+1lZj5Ywg=="],
-
-    "@vibrant/image": ["@vibrant/image@4.0.4", "", { "dependencies": { "@vibrant/color": "^4.0.4" } }, "sha512-NBIJj7umfDRVpFjJHQo1AFSCWCzQyjfil+Yxu7W62PEL72GPCif0CDiglPkvVF8QhDLmnx/x1k3LIBb9jWF2sw=="],
-
-    "@vibrant/image-browser": ["@vibrant/image-browser@4.0.4", "", { "dependencies": { "@vibrant/image": "^4.0.4" } }, "sha512-7qVyAm+z9t98iwMDzUgGCwgRg0KBB5RXQFgiO2Um5Izd1wO7BKC0SHVEz2k7sRx3XNfBf+JExp8quPrvSz17gg=="],
-
-    "@vibrant/image-node": ["@vibrant/image-node@4.0.4", "", { "dependencies": { "@jimp/custom": "^0.22.12", "@jimp/plugin-resize": "^0.22.12", "@jimp/types": "^0.22.12", "@vibrant/image": "^4.0.4" } }, "sha512-aG8Ukt9oTa6FWaAV5oBKsBetkKASWH31hZiFJ2R1291f3TZlphUyQTJz5TubucIRsCEl4dgG1xyxFPgse2IABA=="],
-
-    "@vibrant/quantizer": ["@vibrant/quantizer@4.0.4", "", { "dependencies": { "@vibrant/color": "^4.0.4", "@vibrant/image": "^4.0.4", "@vibrant/types": "^4.0.4" } }, "sha512-722CooC2W4mlBiv+zyAsIrIvARnMCN/P2Muo8bnWd0SQlVWFtQnFxJWGOUPOPS4DGe3pGoqmNfvS0let4dICZQ=="],
-
-    "@vibrant/quantizer-mmcq": ["@vibrant/quantizer-mmcq@4.0.4", "", { "dependencies": { "@vibrant/color": "^4.0.4", "@vibrant/image": "^4.0.4", "@vibrant/quantizer": "^4.0.4" } }, "sha512-/1CNnM96J8K+OBCWNUzywo6VdnmdFJyiKO+ty/nkfe8H0NseOEHIL7PrVtWGgtsb0rh2uTAq2rjXv65TfgPy8g=="],
-
-    "@vibrant/types": ["@vibrant/types@4.0.4", "", {}, "sha512-Qq3mVTJamn7yD4OBgBEUKaxfDlm3sxBK55N7dH3XzI9Ey7KR00R06uwtqOcEJMsziWTEXdYN3VUlYaj2Tkt7hw=="],
-
-    "@vibrant/worker": ["@vibrant/worker@4.0.4", "", { "dependencies": { "@vibrant/types": "^4.0.4" } }, "sha512-Q/R6PYhSMWCXEk/IcXbWIzIu7Z4b58ABkGvcdF8Y+q/7g+KnpxKW5x/jfQ/6ciyYSby13wZZoEdNr3QQVgsdBQ=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
@@ -604,8 +547,6 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.12", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ=="],
 
-    "before-after-hook": ["before-after-hook@2.2.3", "", {}, "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="],
-
     "better-auth": ["better-auth@1.5.6", "", { "dependencies": { "@better-auth/core": "1.5.6", "@better-auth/drizzle-adapter": "1.5.6", "@better-auth/kysely-adapter": "1.5.6", "@better-auth/memory-adapter": "1.5.6", "@better-auth/mongo-adapter": "1.5.6", "@better-auth/prisma-adapter": "1.5.6", "@better-auth/telemetry": "1.5.6", "@better-auth/utils": "0.3.1", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.2", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.12", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-QSpJTqaT1XVfWRQe/fm3PgeuwOIlz1nWX/Dx7nsHStJ382bLzmDbQk2u7IT0IJ6wS5SRxfqEE1Ev9TXontgyAQ=="],
 
     "better-call": ["better-call@1.3.2", "", { "dependencies": { "@better-auth/utils": "^0.3.1", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw=="],
@@ -626,6 +567,8 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
+    "buffer-equal": ["buffer-equal@0.0.1", "", {}, "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="],
+
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
@@ -638,11 +581,11 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001781", "", {}, "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw=="],
 
+    "centra": ["centra@2.7.0", "", { "dependencies": { "follow-redirects": "^1.15.6" } }, "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg=="],
+
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
-
-    "checkout": ["checkout@github:actions/checkout#0c366fd", { "dependencies": { "@actions/core": "^1.10.1", "@actions/exec": "^1.1.1", "@actions/github": "^6.0.0", "@actions/io": "^1.1.3", "@actions/tool-cache": "^2.0.1", "uuid": "^9.0.1" } }, "actions-checkout-0c366fd", "sha512-8PJbfNhS//vu8clPU69bcM/7LS0mQ87H8aVT89V5sFfEnc9f8iYfeglHufFFOX5OMdHbAY+c3iPR5erNNbj8IQ=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
@@ -696,11 +639,9 @@
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
-    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+    "defu": ["defu@6.1.6", "", {}, "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
-    "deprecation": ["deprecation@2.3.1", "", {}, "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="],
 
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 
@@ -709,6 +650,8 @@
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "dom-walk": ["dom-walk@0.1.2", "", {}, "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="],
 
     "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
 
@@ -810,7 +753,7 @@
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
-    "file-type": ["file-type@22.0.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-cmBmnYo8Zymabm2+qAP7jTFbKF10bQpYmxoGfuZbRFRcq00BRddJdGNH/P7GA1EMpJy5yQbqa9B7yROb3z8Ziw=="],
+    "file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -821,6 +764,8 @@
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
@@ -850,9 +795,11 @@
 
     "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
-    "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
+    "gifwrap": ["gifwrap@0.9.4", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "global": ["global@4.4.0", "", { "dependencies": { "min-document": "^2.19.0", "process": "^0.11.10" } }, "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w=="],
 
     "globals": ["globals@17.4.0", "", {}, "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw=="],
 
@@ -910,6 +857,8 @@
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
+    "is-function": ["is-function@1.0.2", "", {}, "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
@@ -941,8 +890,6 @@
     "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
-    "isomorphic-fetch": ["isomorphic-fetch@3.0.0", "", { "dependencies": { "node-fetch": "^2.6.1", "whatwg-fetch": "^3.4.1" } }, "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -1006,7 +953,11 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
+    "load-bmfont": ["load-bmfont@1.4.2", "", { "dependencies": { "buffer-equal": "0.0.1", "mime": "^1.3.4", "parse-bmfont-ascii": "^1.0.3", "parse-bmfont-binary": "^1.0.5", "parse-bmfont-xml": "^1.1.4", "phin": "^3.7.1", "xhr": "^2.0.1", "xtend": "^4.0.0" } }, "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog=="],
+
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
@@ -1030,6 +981,8 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
@@ -1038,11 +991,15 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "min-document": ["min-document@2.19.2", "", { "dependencies": { "dom-walk": "^0.1.0" } }, "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A=="],
+
     "miniflare": ["miniflare@4.20260317.3", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.4", "workerd": "1.20260317.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-tK78D3X4q30/SXqVwMhWrUfH+ffRou9dJLC+jkhNy5zh1I7i7T4JH6xihOvYxdCSBavJ5fQXaaxDJz6orh09BA=="],
 
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -1066,7 +1023,7 @@
 
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
-    "node-vibrant": ["node-vibrant@4.0.4", "", { "dependencies": { "@types/node": "^18.15.3", "@vibrant/core": "^4.0.4", "@vibrant/generator-default": "^4.0.4", "@vibrant/image-browser": "^4.0.4", "@vibrant/image-node": "^4.0.4", "@vibrant/quantizer-mmcq": "^4.0.4" } }, "sha512-hA/pUXBE9TJ41G9FlTkzeqD5JdxgvvPGYZb/HNpdkaxxXUEnP36imSolZ644JuPun+lTd+FpWWtBpTYdp2noQA=="],
+    "node-vibrant": ["node-vibrant@3.1.6", "", { "dependencies": { "@jimp/custom": "^0.16.1", "@jimp/plugin-resize": "^0.16.1", "@jimp/types": "^0.16.1", "@types/lodash": "^4.14.53", "@types/node": "^10.11.7", "lodash": "^4.17.20", "url": "^0.11.0" } }, "sha512-Wlc/hQmBMOu6xon12ZJHS2N3M+I6J8DhrD3Yo6m5175v8sFkVIN+UjhKVRcO+fqvre89ASTpmiFEP3nPO13SwA=="],
 
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
 
@@ -1110,6 +1067,14 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
+    "parse-bmfont-ascii": ["parse-bmfont-ascii@1.0.6", "", {}, "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="],
+
+    "parse-bmfont-binary": ["parse-bmfont-binary@1.0.6", "", {}, "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="],
+
+    "parse-bmfont-xml": ["parse-bmfont-xml@1.1.6", "", { "dependencies": { "xml-parse-from-string": "^1.0.0", "xml2js": "^0.5.0" } }, "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA=="],
+
+    "parse-headers": ["parse-headers@2.0.6", "", {}, "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="],
+
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
@@ -1130,6 +1095,8 @@
 
     "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
 
+    "phin": ["phin@2.9.3", "", {}, "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -1140,7 +1107,7 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
-    "pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+    "pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
@@ -1162,7 +1129,7 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+    "punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
 
     "qr.js": ["qr.js@0.0.0", "", {}, "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="],
 
@@ -1224,6 +1191,8 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -1284,7 +1253,7 @@
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
-    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+    "strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
@@ -1314,11 +1283,9 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+    "token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
 
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
-
-    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
@@ -1327,8 +1294,6 @@
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -1340,8 +1305,6 @@
 
     "typescript-eslint": ["typescript-eslint@8.57.2", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.57.2", "@typescript-eslint/parser": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2", "@typescript-eslint/utils": "8.57.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A=="],
 
-    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
-
     "undici": ["undici@8.0.0", "", {}, "sha512-RGabV5g1ggSX5mU4k+B8BLWgb418gDbg0wAVFeiU00iOxtw4ufGsE6GFsuSd2uqOKooWSLf71JGapOFYpE8f+A=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
@@ -1349,8 +1312,6 @@
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
-
-    "universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
@@ -1362,11 +1323,11 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
-    "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
+    "url": ["url@0.11.4", "", { "dependencies": { "punycode": "^1.4.1", "qs": "^6.12.3" } }, "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg=="],
+
+    "utif": ["utif@2.0.1", "", { "dependencies": { "pako": "^1.0.5" } }, "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
-    "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
@@ -1375,12 +1336,6 @@
     "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
-
-    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
-
-    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
-
-    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -1397,6 +1352,16 @@
     "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
+    "xhr": ["xhr@2.6.0", "", { "dependencies": { "global": "~4.4.0", "is-function": "^1.0.1", "parse-headers": "^2.0.0", "xtend": "^4.0.0" } }, "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA=="],
+
+    "xml-parse-from-string": ["xml-parse-from-string@1.0.1", "", {}, "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="],
+
+    "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
+
+    "xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -1424,12 +1389,6 @@
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
-    "@actions/github/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
-
-    "@actions/http-client/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
-
-    "@actions/tool-cache/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
@@ -1448,8 +1407,6 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@jimp/core/file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
-
     "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
@@ -1467,10 +1424,6 @@
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@12.6.0", "", { "dependencies": { "@octokit/openapi-types": "^20.0.0" } }, "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw=="],
-
-    "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@12.6.0", "", { "dependencies": { "@octokit/openapi-types": "^20.0.0" } }, "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -1506,7 +1459,7 @@
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
-    "isomorphic-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+    "load-bmfont/phin": ["phin@3.7.1", "", { "dependencies": { "centra": "^2.7.0" } }, "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
@@ -1514,13 +1467,11 @@
 
     "miniflare/undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
 
-    "node-vibrant/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+    "node-vibrant/@types/node": ["@types/node@10.17.60", "", {}, "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "ora/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "pixelmatch/pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -1542,6 +1493,8 @@
 
     "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
+    "uri-js/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -1560,23 +1513,13 @@
 
     "@dotenvx/dotenvx/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
-    "@jimp/core/file-type/strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
-
-    "@jimp/core/file-type/token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
-
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@20.0.0", "", {}, "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="],
-
-    "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@20.0.0", "", {}, "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="],
-
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "node-vibrant/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "ora/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "shadcn": {
+      "command": "npx",
+      "args": ["shadcn@latest", "mcp"]
+    }
+  }
+}

--- a/migrations/0018_user-song-likes.sql
+++ b/migrations/0018_user-song-likes.sql
@@ -1,0 +1,15 @@
+-- User song likes table for discovery algorithm foundation
+-- Users can like/unlike individual tracks across all sets
+
+CREATE TABLE IF NOT EXISTS user_song_likes (
+  user_id TEXT NOT NULL,
+  song_id TEXT NOT NULL REFERENCES songs(id) ON DELETE CASCADE,
+  liked_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, song_id)
+);
+
+-- Index for fetching user's liked songs
+CREATE INDEX IF NOT EXISTS idx_user_song_likes_user ON user_song_likes(user_id, liked_at DESC);
+
+-- Index for song like counts
+CREATE INDEX IF NOT EXISTS idx_user_song_likes_song ON user_song_likes(song_id);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zephyron",
   "private": true,
-  "version": "0.3.3-alpha",
+  "version": "0.3.4-alpha",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,9 @@
     "@better-auth/api-key": "^1.5.6",
     "@opentelemetry/api": "^1.9.1",
     "better-auth": "^1.5.6",
-    "checkout": "actions/checkout",
-    "file-type": "^22.0.0",
     "kysely-d1": "^0.4.0",
     "nanoid": "^5.1.7",
-    "node-vibrant": "^4.0.4",
+    "node-vibrant": "3.1.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-icons": "^5.6.0",
@@ -53,5 +51,8 @@
   },
   "trustedDependencies": [
     "@swc/core"
-  ]
+  ],
+  "resolutions": {
+    "defu": "6.1.6"
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { SearchPage } from './pages/SearchPage'
 import { PlaylistsPage } from './pages/PlaylistsPage'
 import { PlaylistPage } from './pages/PlaylistPage'
 import { HistoryPage } from './pages/HistoryPage'
+import { LikedSongsPage } from './pages/LikedSongsPage'
 import { AdminPage } from './pages/AdminPage'
 import { ProfilePage } from './pages/ProfilePage'
 import { SettingsPage } from './pages/SettingsPage'
@@ -111,6 +112,7 @@ function App() {
           <Route path="playlists" element={<PlaylistsPage />} />
           <Route path="playlists/:id" element={<PlaylistPage />} />
           <Route path="history" element={<HistoryPage />} />
+          <Route path="liked-songs" element={<LikedSongsPage />} />
           <Route path="artists" element={<ArtistsPage />} />
           <Route path="artists/:id" element={<ArtistPage />} />
           <Route path="events" element={<EventsPage />} />

--- a/src/components/admin/SongsTab.tsx
+++ b/src/components/admin/SongsTab.tsx
@@ -221,6 +221,23 @@ export function SongsTab() {
                     ))}
                 </div>
 
+                {/* Like count */}
+                {(song.like_count ?? 0) > 0 && (
+                  <span
+                    className="text-[10px] font-mono px-1.5 py-0.5 rounded flex items-center gap-1"
+                    style={{
+                      background: "hsl(var(--h3) / 0.1)",
+                      color: "hsl(var(--h3))",
+                    }}
+                    title={`${song.like_count} like${song.like_count !== 1 ? 's' : ''}`}
+                  >
+                    <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 20 20">
+                      <path d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" />
+                    </svg>
+                    {song.like_count}
+                  </span>
+                )}
+
                 {/* Detection count */}
                 {(song.detection_count ?? 0) > 0 && (
                   <span

--- a/src/components/annotations/DetectionRow.tsx
+++ b/src/components/annotations/DetectionRow.tsx
@@ -2,6 +2,7 @@ import { formatTime } from '../../lib/formatTime'
 import { getSongCoverUrl } from '../../lib/api'
 import { getAvailableServices, ServiceIconLink } from '../../lib/services'
 import type { Detection } from '../../lib/types'
+import { LikeButton } from '../ui/LikeButton'
 
 // ═══════════════════════════════════════════
 // Types
@@ -117,14 +118,20 @@ export function DetectionGroup({
             </div>
           </div>
 
-          {/* Service links */}
-          {serviceLinks.length > 0 && (
-            <div className="flex items-center gap-1.5 shrink-0">
-              {serviceLinks.slice(0, 5).map(({ url, service }) => (
-                <ServiceIconLink key={service.key} url={url} service={service} size={14} />
-              ))}
-            </div>
-          )}
+          {/* Actions: Like button + Service links */}
+          <div className="flex items-center gap-2 shrink-0">
+            {/* Like button */}
+            {song && <LikeButton songId={song.id} size={14} />}
+
+            {/* Service links */}
+            {serviceLinks.length > 0 && (
+              <div className="flex items-center gap-1.5">
+                {serviceLinks.slice(0, 5).map(({ url, service }) => (
+                  <ServiceIconLink key={service.key} url={url} service={service} size={14} />
+                ))}
+              </div>
+            )}
+          </div>
         </button>
 
         {/* ═══ "W/" TRACKS — nested underneath ═══ */}
@@ -170,14 +177,20 @@ export function DetectionGroup({
                     </div>
                   </div>
 
-                  {/* Service links (smaller) */}
-                  {wtLinks.length > 0 && (
-                    <div className="flex items-center gap-1 shrink-0">
-                      {wtLinks.slice(0, 3).map(({ url, service }) => (
-                        <ServiceIconLink key={service.key} url={url} service={service} size={12} />
-                      ))}
-                    </div>
-                  )}
+                  {/* Actions: Like button + Service links (smaller) */}
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    {/* Like button */}
+                    {wtSong && <LikeButton songId={wtSong.id} size={12} />}
+
+                    {/* Service links */}
+                    {wtLinks.length > 0 && (
+                      <div className="flex items-center gap-1">
+                        {wtLinks.slice(0, 3).map(({ url, service }) => (
+                          <ServiceIconLink key={service.key} url={url} service={service} size={12} />
+                        ))}
+                      </div>
+                    )}
+                  </div>
                 </button>
               )
             })}

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -2,22 +2,108 @@ import { useRef, useEffect, useCallback, useState } from 'react'
 import { usePlayerStore } from '../../stores/playerStore'
 import { formatTime } from '../../lib/formatTime'
 import { getCoverUrl, fetchStoryboard, type StoryboardData } from '../../lib/api'
-import { ProgressBar } from '../player/ProgressBar'
-import { StoryboardScrubber } from '../player/StoryboardScrubber'
 import { FullScreenPlayer } from '../player/FullScreenPlayer'
+import type { Detection } from '../../lib/types'
 
-import { VolumeSlider } from '../ui/VolumeSlider'
+// ─── Storyboard helpers (inlined from StoryboardScrubber) ───────────────────
+
+interface ThumbnailInfo {
+  spriteUrl: string
+  bgPositionX: number
+  bgPositionY: number
+  thumbWidth: number
+  thumbHeight: number
+}
+
+function getThumbnailPosition(sb: StoryboardData, time: number): ThumbnailInfo | null {
+  if ((!sb.templateUrl && !sb.url) || sb.count === 0 || sb.interval === 0) return null
+  const frameIndex = Math.max(0, Math.min(sb.count - 1, Math.floor(time / (sb.interval / 1000))))
+  const framesPerSheet = sb.storyboardWidth * sb.storyboardHeight
+  const sheetIndex = Math.floor(frameIndex / framesPerSheet)
+  const frameInSheet = frameIndex % framesPerSheet
+  const col = frameInSheet % sb.storyboardWidth
+  const row = Math.floor(frameInSheet / sb.storyboardWidth)
+  const spriteUrl = sb.templateUrl ? sb.templateUrl.replace('$M', String(sheetIndex)) : sb.url
+  return {
+    spriteUrl,
+    bgPositionX: col * sb.width,
+    bgPositionY: row * sb.height,
+    thumbWidth: sb.width,
+    thumbHeight: sb.height,
+  }
+}
+
+// ─── Volume icon component ──────────────────────────────────────────────────
+
+function VolumeButton({ volume, isMuted, onVolumeChange, onToggleMute }: {
+  volume: number
+  isMuted: boolean
+  onVolumeChange: (v: number) => void
+  onToggleMute: () => void
+}) {
+  const effective = isMuted ? 0 : volume
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {/* Icon — mute toggle on click */}
+      <button
+        onClick={onToggleMute}
+        className="text-text-muted hover:text-text-primary transition-colors shrink-0"
+        title={isMuted ? 'Unmute' : 'Mute'}
+      >
+        {isMuted || volume === 0 ? (
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z" />
+          </svg>
+        ) : volume < 0.5 ? (
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z" />
+          </svg>
+        ) : (
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
+          </svg>
+        )}
+      </button>
+
+      {/* Slider — always visible */}
+      <div
+        className="relative rounded-full cursor-pointer"
+        style={{ width: 64, height: 4, background: 'rgba(255,255,255,0.12)' }}
+      >
+        <div
+          className="absolute top-0 left-0 h-full rounded-full pointer-events-none"
+          style={{ width: `${effective * 100}%`, background: 'hsl(var(--h3))', transition: 'width 0.1s linear' }}
+        />
+        <input
+          type="range" min={0} max={1} step={0.01}
+          value={effective}
+          onChange={e => onVolumeChange(parseFloat(e.target.value))}
+          className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+        />
+      </div>
+    </div>
+  )
+}
+
+// ─── Main PlayerBar ─────────────────────────────────────────────────────────
 
 export function PlayerBar() {
   const audioRef = useRef<HTMLAudioElement>(null)
+  const progressRef = useRef<HTMLDivElement>(null)
+
   const {
     currentSet, isPlaying, isLoadingStream, currentTime, duration, volume, isMuted,
-    currentDetection, detections, setAudioElement, togglePlay,
+    currentDetection, detections, isTheaterMode,
+    setAudioElement, togglePlay, seek,
     setCurrentTime, setDuration, setVolume, toggleMute, playNext, playPrevious,
   } = usePlayerStore()
 
   const [storyboard, setStoryboard] = useState<StoryboardData | null>(null)
+  const [hoverTime, setHoverTime] = useState<number | null>(null)
+  const [hoverX, setHoverX] = useState(0)
 
+  // Audio element registration
   useEffect(() => {
     if (audioRef.current) {
       setAudioElement(audioRef.current)
@@ -25,30 +111,54 @@ export function PlayerBar() {
     }
   }, [setAudioElement, volume])
 
-  // Fetch storyboard for the current set
+  // Storyboard fetch
   useEffect(() => {
-    if (!currentSet) {
-      setStoryboard(null)
-      return
-    }
+    if (!currentSet) { setStoryboard(null); return }
     if (currentSet.stream_type === 'invidious' || currentSet.youtube_video_id) {
-      fetchStoryboard(currentSet.id)
-        .then(setStoryboard)
-        .catch(() => setStoryboard(null))
+      fetchStoryboard(currentSet.id).then(setStoryboard).catch(() => setStoryboard(null))
     } else {
       setStoryboard(null)
     }
   }, [currentSet?.id])
 
-  const handleTimeUpdate = useCallback(() => { if (audioRef.current) setCurrentTime(audioRef.current.currentTime) }, [setCurrentTime])
-  const handleLoadedMetadata = useCallback(() => { if (audioRef.current) setDuration(audioRef.current.duration) }, [setDuration])
+  const handleTimeUpdate = useCallback(() => {
+    if (audioRef.current) setCurrentTime(audioRef.current.currentTime)
+  }, [setCurrentTime])
+
+  const handleLoadedMetadata = useCallback(() => {
+    if (audioRef.current) setDuration(audioRef.current.duration)
+  }, [setDuration])
+
   const handleEnded = useCallback(() => { playNext() }, [playNext])
+
   const handleError = useCallback(() => {
     if (audioRef.current) {
       const err = audioRef.current.error
-      console.error('[PlayerBar] Audio error:', err?.code, err?.message, 'src:', audioRef.current.src)
+      console.error('[PlayerBar] Audio error:', err?.code, err?.message)
     }
   }, [])
+
+  // Progress bar interactions
+  const handleProgressClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (!progressRef.current || duration <= 0) return
+    const rect = progressRef.current.getBoundingClientRect()
+    seek(Math.max(0, Math.min(duration, ((e.clientX - rect.left) / rect.width) * duration)))
+  }, [duration, seek])
+
+  const handleProgressMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (!progressRef.current || duration <= 0) return
+    const rect = progressRef.current.getBoundingClientRect()
+    const x = e.clientX - rect.left
+    setHoverX(x)
+    setHoverTime(Math.max(0, Math.min(duration, (x / rect.width) * duration)))
+  }, [duration])
+
+  const handleProgressMouseLeave = useCallback(() => setHoverTime(null), [])
+
+  const progress = duration > 0 ? (currentTime / duration) * 100 : 0
+  const thumbnailInfo = storyboard && hoverTime !== null
+    ? getThumbnailPosition(storyboard, hoverTime)
+    : null
 
   return (
     <>
@@ -61,40 +171,47 @@ export function PlayerBar() {
         preload="auto"
       />
 
-      {currentSet && (
-        <div className="shrink-0 relative">
-          {/* Playing glow line */}
+      {currentSet && !isTheaterMode && (
+        <div className="shrink-0 relative" style={{ height: 62 }}>
+          {/* Playing glow */}
           {isPlaying && (
-            <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-accent/50 to-transparent" />
+            <div
+              className="absolute top-0 left-0 right-0 h-px pointer-events-none"
+              style={{ background: 'linear-gradient(to right, transparent, hsl(var(--h3) / 0.5), transparent)' }}
+            />
           )}
 
+          {/* Main content row — stops 5px before the bottom (progress bar lives there) */}
           <div
-            className="h-[72px] flex items-center px-5 gap-4"
+            className="absolute left-0 right-0 top-0 flex items-center px-5 gap-4"
             style={{
-              background: 'hsl(var(--b5) / 0.9)',
+              bottom: 5,
+              background: 'hsl(var(--b5) / 0.92)',
               backdropFilter: 'blur(16px) saturate(180%)',
               WebkitBackdropFilter: 'blur(16px) saturate(180%)',
             }}
           >
-            {/* Left: set info */}
-            <div className="flex items-center gap-3 min-w-0 w-[240px] shrink-0">
-              <div className="w-11 h-11 rounded-[var(--card-radius)] overflow-hidden flex-shrink-0 bg-surface-overlay"
-                style={{ boxShadow: 'var(--card-border)' }}>
+            {/* Left: cover + set / track info */}
+            <div className="flex items-center gap-3 shrink-0" style={{ width: 220 }}>
+              <div
+                className="w-10 h-10 rounded-[10px] overflow-hidden shrink-0"
+                style={{ boxShadow: 'var(--card-border)', background: 'hsl(var(--b4))' }}
+              >
                 {currentSet.cover_image_r2_key ? (
                   <img src={getCoverUrl(currentSet.id)} alt="" className="w-full h-full object-cover" />
                 ) : (
                   <div className="w-full h-full flex items-center justify-center">
-                    <svg className="w-5 h-5 text-text-muted" fill="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-4 h-4 text-text-muted" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z" />
                     </svg>
                   </div>
                 )}
               </div>
               <div className="min-w-0">
-                <p className="text-sm text-text-primary truncate">{currentSet.title}</p>
-                <p className="text-xs text-text-muted truncate font-mono">
+                <p className="text-[13px] text-text-primary truncate leading-tight">{currentSet.title}</p>
+                <p className="text-[11px] text-text-muted truncate font-mono leading-tight mt-0.5">
                   {isLoadingStream
-                    ? 'Loading stream...'
+                    ? 'Loading...'
                     : currentDetection
                     ? `${currentDetection.track_title}${currentDetection.track_artist ? ` — ${currentDetection.track_artist}` : ''}`
                     : currentSet.artist}
@@ -102,57 +219,43 @@ export function PlayerBar() {
               </div>
             </div>
 
-            {/* Center: controls + progress */}
-            <div className="flex-1 flex flex-col items-center gap-1 max-w-[640px] mx-auto">
-              <div className="flex items-center gap-4">
-                <button onClick={playPrevious} className="hidden sm:block text-text-muted hover:text-text-primary transition-colors">
-                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" /></svg>
-                </button>
-                <button
-                  onClick={togglePlay}
-                  className="w-9 h-9 bg-accent rounded-full flex items-center justify-center hover:bg-accent-hover transition-all"
-                  style={{ boxShadow: '0 2px 8px hsl(var(--h4) / 0.3)' }}
-                  disabled={isLoadingStream}
-                >
-                  {isLoadingStream ? (
-                    <svg className="w-4 h-4 text-white animate-spin" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                    </svg>
-                  ) : isPlaying
-                    ? <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" /></svg>
-                    : <svg className="w-4 h-4 text-white ml-0.5" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>}
-                </button>
-                <button onClick={playNext} className="hidden sm:block text-text-muted hover:text-text-primary transition-colors">
-                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" /></svg>
-                </button>
-              </div>
-              <div className="hidden sm:flex w-full items-center gap-2 relative">
-                <span className="text-[11px] font-mono text-text-muted w-12 text-right tabular-nums">{formatTime(currentTime)}</span>
-                <div className="relative flex-1">
-                  <ProgressBar currentTime={currentTime} duration={duration} detections={detections} />
-                  {/* Storyboard overlay on progress bar */}
-                  {storyboard && (
-                    <div className="absolute inset-0">
-                      <StoryboardScrubber storyboard={storyboard} duration={duration} />
-                    </div>
-                  )}
-                </div>
-                <span className="text-[11px] font-mono text-text-muted w-12 tabular-nums">{formatTime(duration)}</span>
-              </div>
+            {/* Center: time — prev — [play slot] — next — time */}
+            <div className="flex-1 flex items-center justify-center gap-5">
+              <span className="text-[11px] font-mono tabular-nums text-text-muted hidden sm:block w-11 text-right">
+                {formatTime(currentTime)}
+              </span>
+              <button
+                onClick={playPrevious}
+                className="hidden sm:block text-text-muted hover:text-text-primary transition-colors"
+              >
+                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
+                </svg>
+              </button>
+
+              {/* Spacer matching the play button width so layout doesn't collapse */}
+              <div style={{ width: 36, height: 36, flexShrink: 0 }} />
+
+              <button
+                onClick={playNext}
+                className="hidden sm:block text-text-muted hover:text-text-primary transition-colors"
+              >
+                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
+                </svg>
+              </button>
+              <span className="text-[11px] font-mono tabular-nums text-text-muted hidden sm:block w-11">
+                {formatTime(duration)}
+              </span>
             </div>
 
-            {/* Mobile: compact time */}
-            <span className="sm:hidden text-[10px] text-text-muted tabular-nums font-mono flex-shrink-0">{formatTime(currentTime)}</span>
-
-            {/* Right: volume + expand */}
-            <div className="hidden sm:flex items-center gap-3 w-[240px] justify-end shrink-0">
-              <VolumeSlider
+            {/* Right: volume icon + expand */}
+            <div className="hidden sm:flex items-center gap-3 shrink-0 justify-end" style={{ width: 220 }}>
+              <VolumeButton
                 volume={volume}
                 isMuted={isMuted}
                 onVolumeChange={setVolume}
                 onToggleMute={toggleMute}
-                variant="bar"
               />
               <button
                 onClick={usePlayerStore.getState().toggleFullScreen}
@@ -164,6 +267,164 @@ export function PlayerBar() {
                 </svg>
               </button>
             </div>
+
+            {/* Mobile: compact time */}
+            <span className="sm:hidden text-[10px] text-text-muted tabular-nums font-mono shrink-0">
+              {formatTime(currentTime)}
+            </span>
+          </div>
+
+          {/* Play / pause button — absolute, centered vertically in content row, touching progress bar */}
+          <button
+            onClick={togglePlay}
+            disabled={isLoadingStream}
+            style={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              top: 0,
+              bottom: 5,
+              width: 36,
+              height: 36,
+              margin: 'auto',
+              borderRadius: '50%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'hsl(var(--h3))',
+              boxShadow: '0 2px 12px hsl(var(--h4) / 0.35)',
+              transition: 'transform 0.15s ease, box-shadow 0.15s ease',
+              zIndex: 10,
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.transform = 'scale(1.08)'
+              e.currentTarget.style.boxShadow = '0 4px 18px hsl(var(--h4) / 0.5)'
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.transform = ''
+              e.currentTarget.style.boxShadow = '0 2px 12px hsl(var(--h4) / 0.35)'
+            }}
+          >
+            {isLoadingStream ? (
+              <svg className="w-3.5 h-3.5 text-white animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+              </svg>
+            ) : isPlaying ? (
+              <svg className="w-3.5 h-3.5 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
+              </svg>
+            ) : (
+              <svg className="w-3.5 h-3.5 text-white" style={{ marginLeft: 1 }} fill="currentColor" viewBox="0 0 24 24">
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            )}
+          </button>
+
+          {/* Progress bar — full width, absolute bottom, integrates storyboard */}
+          <div
+            ref={progressRef}
+            className="absolute left-0 right-0 bottom-0 cursor-pointer group"
+            style={{ height: 5 }}
+            onClick={handleProgressClick}
+            onMouseMove={handleProgressMouseMove}
+            onMouseLeave={handleProgressMouseLeave}
+          >
+            {/* Track */}
+            <div className="absolute inset-0 rounded-full" style={{ background: 'rgba(255,255,255,0.12)' }} />
+
+            {/* Detection chapter markers */}
+            {detections.map((d: Detection) => {
+              if (duration <= 0) return null
+              const pos = (d.start_time_seconds / duration) * 100
+              return (
+                <div
+                  key={d.id}
+                  className="absolute top-0 h-full opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"
+                  style={{ left: `${pos}%`, width: 1.5, background: 'rgba(255,255,255,0.35)' }}
+                  title={d.track_title}
+                />
+              )
+            })}
+
+            {/* Fill */}
+            <div
+              className="absolute top-0 left-0 h-full rounded-full pointer-events-none"
+              style={{ width: `${progress}%`, background: 'hsl(var(--h3))', transition: 'width 0.1s linear' }}
+            />
+
+            {/* Playhead thumb on hover */}
+            {hoverTime !== null && (
+              <div
+                className="absolute pointer-events-none"
+                style={{
+                  left: `${(hoverTime / duration) * 100}%`,
+                  top: '50%',
+                  transform: 'translate(-50%, -50%)',
+                  width: 11,
+                  height: 11,
+                  borderRadius: '50%',
+                  background: 'white',
+                  boxShadow: '0 1px 5px rgba(0,0,0,0.4)',
+                  transition: 'opacity 0.1s',
+                }}
+              />
+            )}
+
+            {/* Hover time indicator */}
+            {hoverTime !== null && (
+              <div
+                className="absolute top-0 bottom-0 w-px pointer-events-none opacity-40"
+                style={{ left: `${(hoverTime / duration) * 100}%`, background: 'hsl(var(--c2))' }}
+              />
+            )}
+
+            {/* Storyboard thumbnail popup */}
+            {hoverTime !== null && thumbnailInfo && (
+              <div
+                className="absolute pointer-events-none z-20"
+                style={{
+                  bottom: '100%',
+                  left: Math.max(
+                    0,
+                    Math.min(
+                      (progressRef.current?.offsetWidth ?? 0) - thumbnailInfo.thumbWidth,
+                      hoverX - thumbnailInfo.thumbWidth / 2,
+                    ),
+                  ),
+                  marginBottom: 10,
+                }}
+              >
+                <div
+                  className="overflow-hidden rounded-lg"
+                  style={{
+                    width: thumbnailInfo.thumbWidth,
+                    height: thumbnailInfo.thumbHeight,
+                    boxShadow: '0 8px 25px rgba(0,0,0,0.55)',
+                    border: '1px solid hsl(var(--b3) / 0.5)',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: thumbnailInfo.thumbWidth,
+                      height: thumbnailInfo.thumbHeight,
+                      backgroundImage: `url(${thumbnailInfo.spriteUrl})`,
+                      backgroundPosition: `-${thumbnailInfo.bgPositionX}px -${thumbnailInfo.bgPositionY}px`,
+                      backgroundSize: storyboard
+                        ? `${storyboard.storyboardWidth * thumbnailInfo.thumbWidth}px ${storyboard.storyboardHeight * thumbnailInfo.thumbHeight}px`
+                        : undefined,
+                      backgroundRepeat: 'no-repeat',
+                    }}
+                  />
+                </div>
+                <p
+                  className="mt-1 text-center text-[10px] font-mono tabular-nums"
+                  style={{ color: 'hsl(var(--c2))' }}
+                >
+                  {formatTime(hoverTime)}
+                </p>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/src/components/layout/TopNav.tsx
+++ b/src/components/layout/TopNav.tsx
@@ -232,6 +232,11 @@ export function TopNav() {
                     icon: "M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z",
                   },
                   {
+                    to: "/app/liked-songs",
+                    label: "Liked Songs",
+                    icon: "M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z",
+                  },
+                  {
                     to: "/app/request-set",
                     label: "Request a Set",
                     icon: "M12 9v6m3-3H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z",

--- a/src/components/player/CoverFlowView.tsx
+++ b/src/components/player/CoverFlowView.tsx
@@ -3,6 +3,7 @@ import { usePlayerStore } from '../../stores/playerStore'
 import { getSongCoverUrl, getCoverUrl } from '../../lib/api'
 import { getAvailableServices, ServiceIcon } from '../../lib/services'
 import type { Detection, Song } from '../../lib/types'
+import { LikeButton } from '../ui/LikeButton'
 
 // ═══════════════════════════════════════════
 // Types + constants
@@ -389,7 +390,14 @@ function TrackInfo({ group, set, groupIndex, totalGroups }: {
         </>
       )}
 
-      {group?.primary.song && <SongLinks song={group.primary.song} />}
+      {group?.primary.song && (
+        <>
+          <div className="flex items-center justify-center gap-2 mt-3">
+            <LikeButton songId={group.primary.song.id} size={16} showCount />
+          </div>
+          <SongLinks song={group.primary.song} />
+        </>
+      )}
 
       {totalGroups > 0 && groupIndex >= 0 && (
         <p className="text-[10px] font-mono mt-4" style={{ color: 'rgba(255,255,255,0.2)' }}>

--- a/src/components/player/FullScreenPlayer.tsx
+++ b/src/components/player/FullScreenPlayer.tsx
@@ -5,17 +5,46 @@ import { useCurrentTrackCover } from '../../hooks/useCurrentTrackCover'
 import { useAlbumColors } from '../../hooks/useAlbumColors'
 import { VolumeSlider } from '../ui/VolumeSlider'
 import { formatTime } from '../../lib/formatTime'
-import { getSongCoverUrl } from '../../lib/api'
+import { getSongCoverUrl, fetchStoryboard, type StoryboardData } from '../../lib/api'
 import { getAvailableServices, ServiceIconLink } from '../../lib/services'
 import type { Detection } from '../../lib/types'
 
 type AnimState = 'hidden' | 'entering' | 'visible' | 'exiting'
+
+// ─── Storyboard helpers ──────────────────────────────────────────────────────
+
+interface ThumbnailInfo {
+  spriteUrl: string
+  bgPositionX: number
+  bgPositionY: number
+  thumbWidth: number
+  thumbHeight: number
+}
+
+function getThumbnailPosition(sb: StoryboardData, time: number): ThumbnailInfo | null {
+  if ((!sb.templateUrl && !sb.url) || sb.count === 0 || sb.interval === 0) return null
+  const frameIndex = Math.max(0, Math.min(sb.count - 1, Math.floor(time / (sb.interval / 1000))))
+  const framesPerSheet = sb.storyboardWidth * sb.storyboardHeight
+  const sheetIndex = Math.floor(frameIndex / framesPerSheet)
+  const frameInSheet = frameIndex % framesPerSheet
+  const col = frameInSheet % sb.storyboardWidth
+  const row = Math.floor(frameInSheet / sb.storyboardWidth)
+  const spriteUrl = sb.templateUrl ? sb.templateUrl.replace('$M', String(sheetIndex)) : sb.url
+  return {
+    spriteUrl,
+    bgPositionX: col * sb.width,
+    bgPositionY: row * sb.height,
+    thumbWidth: sb.width,
+    thumbHeight: sb.height,
+  }
+}
 
 export function FullScreenPlayer() {
   const {
     currentSet, isPlaying, currentTime, duration, volume, isMuted,
     currentDetection, currentDetections, detections, isFullScreen,
     isVideoMode, videoStreamUrl, isLoadingVideo,
+    isTheaterMode, setTheaterMode,
     togglePlay, seek, setVolume, toggleMute,
     playNext, playPrevious, toggleFullScreen,
     setVideoMode, loadVideoStream, setVideoElement,
@@ -23,6 +52,16 @@ export function FullScreenPlayer() {
 
   const [animState, setAnimState] = useState<AnimState>('hidden')
   const [showTracklist, setShowTracklist] = useState(false)
+  const [showControls, setShowControls] = useState(true)
+  const [upNextDetection, setUpNextDetection] = useState<Detection | null>(null)
+  const [showUpNext, setShowUpNext] = useState(false)
+  const [nowPlayingFlash, setNowPlayingFlash] = useState(false)
+  const [upNextExiting, setUpNextExiting] = useState(false)
+  const [theaterEntering, setTheaterEntering] = useState(false)
+  const [storyboard, setStoryboard] = useState<StoryboardData | null>(null)
+  const [hoverTime, setHoverTime] = useState<number | null>(null)
+  const [hoverX, setHoverX] = useState(0)
+  const [hoverBarWidth, setHoverBarWidth] = useState(0)
   const tracklistRef = useRef<HTMLDivElement>(null)
   const activeTrackRef = useRef<HTMLButtonElement>(null)
   const coverUrl = useCurrentTrackCover()
@@ -30,6 +69,8 @@ export function FullScreenPlayer() {
   const videoRef = useRef<HTMLVideoElement>(null)
   const ambilightRef = useRef<HTMLCanvasElement>(null)
   const syncIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const controlsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const upNextShownForRef = useRef<string | null>(null)
 
   // Ambilight — draws video frames to the canvas at 60fps
   useEffect(() => {
@@ -191,11 +232,32 @@ export function FullScreenPlayer() {
     return groups
   }, [detections])
 
+  // Storyboard fetch
+  useEffect(() => {
+    if (!currentSet) { setStoryboard(null); return }
+    if (currentSet.stream_type === 'invidious' || currentSet.youtube_video_id) {
+      fetchStoryboard(currentSet.id).then(setStoryboard).catch(() => setStoryboard(null))
+    } else {
+      setStoryboard(null)
+    }
+  }, [currentSet?.id])
+
   const handleSeek = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (duration <= 0) return
     const rect = e.currentTarget.getBoundingClientRect()
     seek(((e.clientX - rect.left) / rect.width) * duration)
   }, [duration, seek])
+
+  const handleProgressMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (duration <= 0) return
+    const rect = e.currentTarget.getBoundingClientRect()
+    const x = e.clientX - rect.left
+    setHoverX(x)
+    setHoverBarWidth(rect.width)
+    setHoverTime(Math.max(0, Math.min(duration, (x / rect.width) * duration)))
+  }, [duration])
+
+  const handleProgressMouseLeave = useCallback(() => setHoverTime(null), [])
 
   const handleToggleVideoMode = useCallback((enabled: boolean) => {
     setVideoMode(enabled)
@@ -204,12 +266,104 @@ export function FullScreenPlayer() {
     }
     if (!enabled) {
       setShowTracklist(false)
+      if (isTheaterMode) {
+        setTheaterMode(false)
+        setShowControls(true)
+      }
     }
-  }, [setVideoMode, videoStreamUrl, loadVideoStream])
+  }, [setVideoMode, videoStreamUrl, loadVideoStream, isTheaterMode, setTheaterMode])
+
+  // Fire theaterEntering animation whenever theater mode turns on
+  useEffect(() => {
+    if (!isTheaterMode) return
+    setTheaterEntering(true)
+    const t = setTimeout(() => setTheaterEntering(false), 400)
+    return () => clearTimeout(t)
+  }, [isTheaterMode])
+
+  // Theater mode toggle — also requests/exits browser fullscreen on the FullScreenPlayer root
+  const fullscreenTargetRef = useRef<HTMLDivElement>(null)
+
+  const handleToggleTheater = useCallback(() => {
+    const next = !isTheaterMode
+    setTheaterMode(next)
+    if (next) {
+      // Enter browser fullscreen
+      const el = fullscreenTargetRef.current
+      if (el && !document.fullscreenElement) {
+        el.requestFullscreen().catch(() => {})
+      }
+      setShowControls(true)
+      if (controlsTimerRef.current) clearTimeout(controlsTimerRef.current)
+      controlsTimerRef.current = setTimeout(() => setShowControls(false), 3000)
+    } else {
+      // Exit browser fullscreen
+      if (document.fullscreenElement) {
+        document.exitFullscreen().catch(() => {})
+      }
+      setShowControls(true)
+      if (controlsTimerRef.current) clearTimeout(controlsTimerRef.current)
+    }
+  }, [isTheaterMode, setTheaterMode])
+
+  // If user presses the browser's native Esc/exit-fullscreen, also clear theater mode
+  useEffect(() => {
+    const onFsChange = () => {
+      if (!document.fullscreenElement && isTheaterMode) {
+        setTheaterMode(false)
+        setShowControls(true)
+        if (controlsTimerRef.current) clearTimeout(controlsTimerRef.current)
+      }
+    }
+    document.addEventListener('fullscreenchange', onFsChange)
+    return () => document.removeEventListener('fullscreenchange', onFsChange)
+  }, [isTheaterMode, setTheaterMode])
+
+  // Show controls on mouse move anywhere in theater mode, hide after 3s of inactivity
+  const handleTheaterMouseMove = useCallback(() => {
+    if (!isTheaterMode) return
+    setShowControls(true)
+    if (controlsTimerRef.current) clearTimeout(controlsTimerRef.current)
+    controlsTimerRef.current = setTimeout(() => setShowControls(false), 3000)
+  }, [isTheaterMode])
+
+  // "Up Next" notification — appear 15s before next track, stay until it starts
+  useEffect(() => {
+    if (!isTheaterMode || detections.length === 0) return
+    const nextDetection = detections.find(d => d.start_time_seconds > currentTime)
+    if (!nextDetection) return
+    const timeUntilNext = nextDetection.start_time_seconds - currentTime
+    if (timeUntilNext <= 15 && timeUntilNext > 0 && upNextShownForRef.current !== nextDetection.id) {
+      upNextShownForRef.current = nextDetection.id
+      setUpNextDetection(nextDetection)
+      setShowUpNext(true)
+      // No auto-dismiss — it stays until the track starts (see effect below)
+    }
+  }, [currentTime, detections, isTheaterMode])
+
+  // When the up-next track becomes current: exit animation → collapse → promote flash
+  useEffect(() => {
+    if (!upNextDetection || !currentDetection) return
+    if (currentDetection.id === upNextDetection.id && showUpNext) {
+      // Phase 1: up-next row flies upward (300ms)
+      setUpNextExiting(true)
+      const t1 = setTimeout(() => {
+        // Phase 2: collapse max-height, trigger now-playing flash
+        setShowUpNext(false)
+        setUpNextExiting(false)
+        setNowPlayingFlash(true)
+        const t2 = setTimeout(() => setNowPlayingFlash(false), 1100)
+        return () => clearTimeout(t2)
+      }, 280)
+      return () => clearTimeout(t1)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentDetection?.id])
 
   if (animState === 'hidden' || !currentSet) return null
 
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0
+  const thumbnailInfo = storyboard && hoverTime !== null ? getThumbnailPosition(storyboard, hoverTime) : null
   const isVisible = animState === 'visible'
   const isEntering = animState === 'entering' || animState === 'visible'
 
@@ -218,8 +372,14 @@ export function FullScreenPlayer() {
   const songCover = song?.cover_art_r2_key ? getSongCoverUrl(song.id) : song?.cover_art_url || song?.lastfm_album_art || null
   const serviceLinks = song ? getAvailableServices(song as unknown as Record<string, unknown>) : []
 
+  // Concurrent tracks playing alongside the up-next detection (within 2s)
+  const upNextConcurrent = upNextDetection
+    ? detections.filter(d => d.id !== upNextDetection.id && Math.abs(d.start_time_seconds - upNextDetection.start_time_seconds) <= 2)
+    : []
+
   return (
     <div
+      ref={fullscreenTargetRef}
       className="fixed inset-0 z-50 flex flex-col"
       style={{
         background: '#050507',
@@ -265,9 +425,20 @@ export function FullScreenPlayer() {
       <div
         className="relative z-10 flex flex-col h-full"
         style={{ opacity: isVisible ? 1 : 0, transition: 'opacity 0.3s ease 0.1s' }}
+        onMouseMove={handleTheaterMouseMove}
       >
         {/* Top bar — toggle + close */}
-        <div className="flex items-center justify-between px-6 h-12 shrink-0">
+        <div
+          className="flex items-center justify-between px-6 h-12 shrink-0"
+          style={isTheaterMode ? {
+            position: 'absolute', top: 0, left: 0, right: 0, zIndex: 30,
+            opacity: showControls ? 1 : 0,
+            transform: showControls ? 'translateY(0)' : 'translateY(-100%)',
+            transition: 'opacity 0.4s ease, transform 0.4s ease',
+            pointerEvents: showControls ? 'auto' : 'none',
+            background: 'linear-gradient(to bottom, rgba(0,0,0,0.6) 0%, transparent 100%)',
+          } : undefined}
+        >
           <span className="text-[10px] font-mono tracking-widest" style={{ color: 'rgba(255,255,255,0.3)' }}>NOW PLAYING</span>
           <div className="flex items-center gap-3">
             {/* Audio / Video pill toggle */}
@@ -301,6 +472,32 @@ export function FullScreenPlayer() {
               </div>
             )}
 
+            {/* Theater mode button — only in video mode */}
+            {hasVideo && isVideoMode && (
+              <button
+                onClick={handleToggleTheater}
+                className="w-8 h-8 rounded-full flex items-center justify-center transition-all"
+                style={{
+                  color: isTheaterMode ? 'hsl(var(--h3))' : 'rgba(255,255,255,0.4)',
+                  background: isTheaterMode ? 'hsl(var(--h3) / 0.12)' : 'transparent',
+                  boxShadow: isTheaterMode ? 'inset 0 0 0 1px hsl(var(--h3) / 0.3)' : 'none',
+                }}
+                onMouseEnter={(e) => { if (!isTheaterMode) { e.currentTarget.style.color = 'rgba(255,255,255,0.9)'; e.currentTarget.style.background = 'rgba(255,255,255,0.1)' } }}
+                onMouseLeave={(e) => { if (!isTheaterMode) { e.currentTarget.style.color = 'rgba(255,255,255,0.4)'; e.currentTarget.style.background = '' } }}
+                title={isTheaterMode ? 'Exit Theater Mode' : 'Theater Mode'}
+              >
+                {isTheaterMode ? (
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 9V4.5M9 9H4.5M9 9L3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5m0-4.5l5.25 5.25" />
+                  </svg>
+                ) : (
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
+                  </svg>
+                )}
+              </button>
+            )}
+
             {/* Close */}
             <button
               onClick={toggleFullScreen}
@@ -318,7 +515,7 @@ export function FullScreenPlayer() {
         </div>
 
         {/* Main area — CoverFlow or Video with crossfade */}
-        <div className="flex-1 min-h-0 relative">
+        <div className={isTheaterMode ? 'absolute inset-0' : 'flex-1 min-h-0 relative'}>
           {/* CoverFlow (audio mode) */}
           <div
             className="absolute inset-0"
@@ -342,6 +539,8 @@ export function FullScreenPlayer() {
               filter: isVideoMode ? 'blur(0)' : 'blur(4px)',
               transition: 'opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.05s, transform 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.05s, filter 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.05s',
               pointerEvents: isVideoMode ? 'auto' : 'none',
+              background: isTheaterMode ? '#000' : 'transparent',
+              cursor: isTheaterMode && !showControls ? 'none' : undefined,
             }}
           >
             {/* Ambilight canvas */}
@@ -364,23 +563,31 @@ export function FullScreenPlayer() {
 
             {/* Video + Tracklist */}
             <div
-              className="relative flex items-center w-full h-full justify-center px-8"
-              style={{ zIndex: 1 }}
+              className="relative flex items-center w-full h-full justify-center"
+              style={{ zIndex: 1, padding: isTheaterMode ? 0 : '0 32px' }}
             >
               {/* Centering wrapper — shifts left when tracklist opens */}
               <div
                 style={{
-                  maxWidth: '960px',
+                  maxWidth: isTheaterMode ? 'none' : '960px',
                   width: '100%',
+                  height: isTheaterMode ? '100%' : undefined,
                   position: 'relative',
-                  transform: showTracklist ? 'translateX(-150px)' : 'translateX(0)',
+                  transform: !isTheaterMode && showTracklist ? 'translateX(-150px)' : 'translateX(0)',
                   transition: 'transform 0.5s cubic-bezier(0.16, 1, 0.3, 1)',
                 }}
               >
                 {/* Video */}
                 <div
                   className="relative w-full overflow-hidden"
-                  style={{
+                  style={isTheaterMode ? {
+                    position: 'absolute',
+                    inset: 0,
+                    borderRadius: 0,
+                    boxShadow: 'none',
+                    background: '#000',
+                    animation: theaterEntering ? 'theaterExpand 0.55s cubic-bezier(0.16, 1, 0.3, 1)' : undefined,
+                  } : {
                     aspectRatio: '16 / 9',
                     borderRadius: showTracklist
                       ? 'var(--card-radius) 0 0 var(--card-radius)'
@@ -403,10 +610,13 @@ export function FullScreenPlayer() {
                   )}
                 </div>
 
-                {/* Toggle + Tracklist — anchored to video right edge, grows outward */}
+                {/* Toggle + Tracklist — anchored to right edge (fixed overlay in theater mode) */}
                 <div
-                  className="absolute top-0 bottom-0 flex"
-                  style={{ left: '100%' }}
+                  className="absolute flex"
+                  style={isTheaterMode
+                    ? { top: '50%', transform: 'translateY(-50%)', right: 0, left: 'auto', flexDirection: 'row-reverse', maxHeight: 'min(480px, calc(100% - 200px))' }
+                    : { top: 0, bottom: 0, left: '100%' }
+                  }
                 >
                   {/* Tracklist panel — expands first (button moves with it) */}
                   <div
@@ -415,15 +625,16 @@ export function FullScreenPlayer() {
                     style={{
                       width: showTracklist ? 300 : 0,
                       opacity: showTracklist ? 1 : 0,
+                      maxHeight: isTheaterMode ? '100%' : undefined,
                       background: 'rgba(0, 0, 0, 0.5)',
                       backdropFilter: 'blur(24px)',
                       WebkitBackdropFilter: 'blur(24px)',
-                      borderRadius: '0 12px 12px 0',
+                      borderRadius: isTheaterMode ? '12px 0 0 12px' : '0 12px 12px 0',
                       boxShadow: showTracklist ? 'inset 0 0 0 1px rgba(255,255,255,0.06)' : 'none',
                       transition: 'width 0.5s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.35s cubic-bezier(0.16, 1, 0.3, 1)',
                     }}
                   >
-                    <div className="flex flex-col h-full" style={{ width: 300 }}>
+                    <div className="flex flex-col" style={{ width: 300, height: isTheaterMode ? undefined : '100%', maxHeight: isTheaterMode ? '100%' : undefined }}>
                       <div className="px-4 pt-3 pb-2 shrink-0">
                         <div className="flex items-center justify-between">
                           <p className="text-[11px] font-mono tracking-wider" style={{ color: 'rgba(255,255,255,0.35)' }}>TRACKLIST</p>
@@ -647,7 +858,7 @@ export function FullScreenPlayer() {
                     style={{
                       width: 20,
                       height: 40,
-                      borderRadius: '0 6px 6px 0',
+                      borderRadius: isTheaterMode ? '6px 0 0 6px' : '0 6px 6px 0',
                       background: 'rgba(255,255,255,0.06)',
                       backdropFilter: 'blur(12px)',
                       WebkitBackdropFilter: 'blur(12px)',
@@ -663,7 +874,9 @@ export function FullScreenPlayer() {
                       className="w-3 h-3"
                       fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
                       style={{
-                        transform: showTracklist ? 'rotate(180deg)' : 'rotate(0deg)',
+                        transform: isTheaterMode
+                          ? (showTracklist ? 'rotate(0deg)' : 'rotate(180deg)')
+                          : (showTracklist ? 'rotate(180deg)' : 'rotate(0deg)'),
                         transition: 'transform 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
                       }}
                     >
@@ -674,12 +887,295 @@ export function FullScreenPlayer() {
               </div>
             </div>
           </div>
+
+          {/* ── THEATER MODE OVERLAYS ── */}
+
+          {/* Now Playing card — slides up when controls hide, Up Next expands below */}
+          {isTheaterMode && (
+            <div
+              style={{
+                position: 'absolute',
+                // when controls are hidden, slide up to top-right corner (16px from edge)
+                top: showControls ? 68 : 16,
+                right: 16,
+                zIndex: 110,
+                backdropFilter: 'blur(24px) saturate(180%)',
+                WebkitBackdropFilter: 'blur(24px) saturate(180%)',
+                background: 'rgba(0,0,0,0.6)',
+                boxShadow: nowPlayingFlash
+                  ? 'inset 0 0 0 1.5px hsl(var(--h3) / 0.6), 0 8px 32px hsl(var(--h4) / 0.4)'
+                  : 'inset 0 0 0 1px rgba(255,255,255,0.1), 0 12px 40px rgba(0,0,0,0.5)',
+                borderRadius: 14,
+                overflow: 'hidden',
+                width: 260,
+                transition: 'top 0.65s cubic-bezier(0.34, 1.4, 0.64, 1), right 0.65s cubic-bezier(0.34, 1.4, 0.64, 1), box-shadow 0.4s ease',
+                animation: nowPlayingFlash ? 'nowPlayingFlash 1.1s cubic-bezier(0.16, 1, 0.3, 1)' : undefined,
+              }}
+            >
+              {/* Now Playing row */}
+              <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, padding: '10px 12px' }}>
+                <div
+                  className="relative shrink-0 rounded-lg overflow-hidden"
+                  style={{
+                    width: 40, height: 40,
+                    boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.12)',
+                    animation: nowPlayingFlash ? 'coverPromote 0.7s cubic-bezier(0.16, 1, 0.3, 1)' : undefined,
+                  }}
+                >
+                  {songCover ? (
+                    <img key={songCover} src={songCover} alt="" className="absolute inset-0 w-full h-full object-cover" style={{ animation: 'coverFadeIn 0.45s cubic-bezier(0.16, 1, 0.3, 1)' }} />
+                  ) : (
+                    <div className="absolute inset-0 flex items-center justify-center" style={{ background: 'rgba(255,255,255,0.06)' }}>
+                      <svg className="w-4 h-4" style={{ color: 'rgba(255,255,255,0.2)' }} fill="currentColor" viewBox="0 0 24 24"><path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" /></svg>
+                    </div>
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p style={{
+                    fontSize: 9,
+                    fontFamily: 'var(--font-mono, monospace)',
+                    letterSpacing: '0.1em',
+                    color: 'hsl(var(--h3) / 0.7)',
+                    marginBottom: 2,
+                    animation: nowPlayingFlash ? 'labelFlash 0.8s cubic-bezier(0.16, 1, 0.3, 1)' : undefined,
+                  }}>NOW PLAYING</p>
+                  <p key={currentDetection?.id} style={{ fontSize: 11, color: 'rgba(255,255,255,0.92)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', lineHeight: 1.3, animation: nowPlayingFlash ? 'nowPlayingTextPop 0.5s cubic-bezier(0.16, 1, 0.3, 1)' : 'titleSlideIn 0.3s ease-out' }}>
+                    {currentDetection?.track_title || currentSet.title}
+                  </p>
+                  {(currentDetection?.track_artist || currentSet.artist) && (
+                    <p style={{ fontSize: 10, color: 'rgba(255,255,255,0.4)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {currentDetection?.track_artist || currentSet.artist}
+                    </p>
+                  )}
+                  {/* Concurrent tracks (w/) */}
+                  {currentDetections.slice(1).map((d) => {
+                    const dSong = d.song
+                    const dCover = dSong?.cover_art_r2_key ? getSongCoverUrl(dSong.id) : dSong?.cover_art_url || dSong?.lastfm_album_art || null
+                    return (
+                      <div key={d.id} style={{ marginTop: 6, paddingLeft: 8, borderLeft: '1.5px solid rgba(255,255,255,0.1)', display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <div className="relative shrink-0 rounded overflow-hidden" style={{ width: 26, height: 26, boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.08)' }}>
+                          {dCover ? (
+                            <img src={dCover} alt="" className="absolute inset-0 w-full h-full object-cover" style={{ opacity: 0.8 }} />
+                          ) : (
+                            <div className="absolute inset-0 flex items-center justify-center" style={{ background: 'rgba(255,255,255,0.04)' }}>
+                              <svg className="w-3 h-3" style={{ color: 'rgba(255,255,255,0.15)' }} fill="currentColor" viewBox="0 0 24 24"><path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" /></svg>
+                            </div>
+                          )}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p style={{ fontSize: 8, fontFamily: 'var(--font-mono, monospace)', letterSpacing: '0.08em', color: 'hsl(var(--h3) / 0.5)', marginBottom: 1 }}>w/</p>
+                          <p style={{ fontSize: 10, color: 'rgba(255,255,255,0.72)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', lineHeight: 1.3 }}>{d.track_title}</p>
+                          {d.track_artist && (
+                            <p style={{ fontSize: 9, color: 'rgba(255,255,255,0.35)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.track_artist}</p>
+                          )}
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+
+              {/* Up Next — slides down inside the same card */}
+              {upNextDetection && (
+                <div style={{
+                  maxHeight: showUpNext ? (upNextConcurrent.length > 0 ? 72 : 56) : 0,
+                  overflow: 'hidden',
+                  transition: 'max-height 0.5s cubic-bezier(0.16, 1, 0.3, 1)',
+                }}>
+                  {/* Divider — fades in with the row */}
+                  <div style={{
+                    height: 1,
+                    background: 'rgba(255,255,255,0.07)',
+                    margin: '0 12px',
+                    opacity: showUpNext ? 1 : 0,
+                    transition: 'opacity 0.2s ease 0.15s',
+                  }} />
+                  <div style={{
+                    display: 'flex', alignItems: 'center', gap: 8,
+                    padding: '7px 12px 9px 20px',
+                    animation: upNextExiting
+                      ? 'upNextExit 0.28s cubic-bezier(0.4, 0, 1, 1) forwards'
+                      : showUpNext
+                      ? 'upNextEntry 0.55s cubic-bezier(0.34, 1.3, 0.64, 1)'
+                      : undefined,
+                    opacity: showUpNext && !upNextExiting ? 1 : undefined,
+                  }}>
+                    {/* Small connector dot */}
+                    <div style={{ width: 4, height: 4, borderRadius: '50%', background: 'rgba(255,255,255,0.2)', flexShrink: 0 }} />
+                    {/* Cover stack — main cover + offset thumbnail if concurrent */}
+                    {(() => {
+                      const upNextSong = upNextDetection.song
+                      const upNextCover = upNextSong?.cover_art_r2_key ? getSongCoverUrl(upNextSong.id) : upNextSong?.cover_art_url || upNextSong?.lastfm_album_art || null
+                      const secondaryCover = upNextConcurrent.length > 0 ? (() => {
+                        const s = upNextConcurrent[0].song
+                        return s?.cover_art_r2_key ? getSongCoverUrl(s.id) : s?.cover_art_url || s?.lastfm_album_art || null
+                      })() : null
+                      return (
+                        <div style={{ position: 'relative', width: 26 + (upNextConcurrent.length > 0 ? 8 : 0), height: 26, flexShrink: 0 }}>
+                          {/* Offset secondary cover behind */}
+                          {secondaryCover && (
+                            <div className="absolute rounded overflow-hidden" style={{ width: 22, height: 22, top: 2, left: 8, opacity: 0.45, boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.08)' }}>
+                              <img src={secondaryCover} alt="" className="w-full h-full object-cover" />
+                            </div>
+                          )}
+                          {/* Primary cover on top */}
+                          <div className="absolute rounded overflow-hidden" style={{ width: 26, height: 26, left: 0, top: 0, opacity: 0.7, boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.1)' }}>
+                            {upNextCover ? (
+                              <img src={upNextCover} alt="" className="w-full h-full object-cover" />
+                            ) : (
+                              <div className="w-full h-full flex items-center justify-center" style={{ background: 'rgba(255,255,255,0.04)' }}>
+                                <svg className="w-3 h-3" style={{ color: 'rgba(255,255,255,0.15)' }} fill="currentColor" viewBox="0 0 24 24"><path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" /></svg>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      )
+                    })()}
+                    <div className="min-w-0 flex-1">
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 1 }}>
+                        <p style={{ fontSize: 8, fontFamily: 'var(--font-mono, monospace)', letterSpacing: '0.08em', color: 'rgba(255,255,255,0.28)' }}>UP NEXT</p>
+                        {upNextConcurrent.length > 0 && (
+                          <span style={{ fontSize: 7, fontFamily: 'var(--font-mono, monospace)', letterSpacing: '0.06em', color: 'hsl(var(--h3) / 0.6)', background: 'hsl(var(--h3) / 0.12)', padding: '1px 4px', borderRadius: 4 }}>
+                            +{upNextConcurrent.length}
+                          </span>
+                        )}
+                      </div>
+                      <p style={{ fontSize: 10, color: 'rgba(255,255,255,0.55)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', lineHeight: 1.3 }}>{upNextDetection.track_title}</p>
+                      {upNextConcurrent.length > 0 && (
+                        <p style={{ fontSize: 9, color: 'rgba(255,255,255,0.28)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', lineHeight: 1.3 }}>
+                          w/ {upNextConcurrent.map(d => d.track_title).join(', ')}
+                        </p>
+                      )}
+                    </div>
+                    <button
+                      onClick={() => setShowUpNext(false)}
+                      style={{ color: 'rgba(255,255,255,0.2)', flexShrink: 0, padding: 2 }}
+                      onMouseEnter={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.6)'}
+                      onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.2)'}
+                    >
+                      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Theater controls overlay — hover to reveal, 3s inactivity timeout */}
+          {isTheaterMode && (
+            <div
+              style={{
+                position: 'absolute',
+                bottom: 0, left: 0, right: 0,
+                zIndex: 100,
+                opacity: showControls ? 1 : 0,
+                transform: showControls ? 'translateY(0)' : 'translateY(10px)',
+                transition: 'opacity 0.4s ease, transform 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
+                pointerEvents: showControls ? 'auto' : 'none',
+                background: 'linear-gradient(to top, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.32) 60%, transparent 100%)',
+                filter: 'drop-shadow(0 -8px 40px rgba(0,0,0,0.6))',
+                padding: '36px 48px 18px',
+              }}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+
+                {/* Progress bar — full width with hover + storyboard */}
+                <div
+                  className="relative h-[5px] rounded-full cursor-pointer group"
+                  style={{ background: 'rgba(255,255,255,0.15)', marginBottom: 5 }}
+                  onClick={handleSeek}
+                  onMouseMove={handleProgressMouseMove}
+                  onMouseLeave={handleProgressMouseLeave}
+                >
+                  {/* Detection chapter markers */}
+                  {detections.map((d) => {
+                    if (duration <= 0) return null
+                    const pos = (d.start_time_seconds / duration) * 100
+                    return (
+                      <div
+                        key={d.id}
+                        className="absolute top-0 h-full opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"
+                        style={{ left: `${pos}%`, width: 1.5, background: 'rgba(255,255,255,0.35)' }}
+                      />
+                    )
+                  })}
+                  {/* Fill */}
+                  <div className="absolute top-0 left-0 h-full rounded-full pointer-events-none" style={{ width: `${progress}%`, background: 'hsl(var(--h3))', transition: 'width 0.1s linear' }} />
+                  {/* Hover thumb */}
+                  {hoverTime !== null && (
+                    <div
+                      className="absolute pointer-events-none"
+                      style={{ left: `${(hoverTime / duration) * 100}%`, top: '50%', transform: 'translate(-50%, -50%)', width: 13, height: 13, borderRadius: '50%', background: 'white', boxShadow: '0 1px 5px rgba(0,0,0,0.4)' }}
+                    />
+                  )}
+                  {/* Hover time line */}
+                  {hoverTime !== null && (
+                    <div
+                      className="absolute top-0 bottom-0 w-px pointer-events-none opacity-40"
+                      style={{ left: `${(hoverTime / duration) * 100}%`, background: 'rgba(255,255,255,0.8)' }}
+                    />
+                  )}
+                  {/* Storyboard thumbnail popup */}
+                  {hoverTime !== null && thumbnailInfo && (
+                    <div
+                      className="absolute pointer-events-none z-20"
+                      style={{
+                        bottom: '100%',
+                        left: Math.max(0, Math.min(hoverBarWidth - thumbnailInfo.thumbWidth, hoverX - thumbnailInfo.thumbWidth / 2)),
+                        marginBottom: 12,
+                      }}
+                    >
+                      <div className="overflow-hidden rounded-lg" style={{ width: thumbnailInfo.thumbWidth, height: thumbnailInfo.thumbHeight, boxShadow: '0 8px 25px rgba(0,0,0,0.55)', border: '1px solid rgba(255,255,255,0.1)' }}>
+                        <div style={{ width: thumbnailInfo.thumbWidth, height: thumbnailInfo.thumbHeight, backgroundImage: `url(${thumbnailInfo.spriteUrl})`, backgroundPosition: `-${thumbnailInfo.bgPositionX}px -${thumbnailInfo.bgPositionY}px`, backgroundSize: storyboard ? `${storyboard.storyboardWidth * thumbnailInfo.thumbWidth}px ${storyboard.storyboardHeight * thumbnailInfo.thumbHeight}px` : undefined, backgroundRepeat: 'no-repeat' }} />
+                      </div>
+                      <p className="mt-1 text-center text-[10px] font-mono tabular-nums" style={{ color: 'rgba(255,255,255,0.5)' }}>{formatTime(hoverTime)}</p>
+                    </div>
+                  )}
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 10 }}>
+                  <span style={{ fontSize: 10, fontFamily: 'var(--font-mono, monospace)', color: 'rgba(255,255,255,0.45)' }}>{formatTime(currentTime)}</span>
+                  <span style={{ fontSize: 10, fontFamily: 'var(--font-mono, monospace)', color: 'rgba(255,255,255,0.45)' }}>{formatTime(duration)}</span>
+                </div>
+
+                {/* Transport row */}
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  {/* Left: volume */}
+                  <div style={{ flex: '0 0 200px' }}>
+                    <VolumeSlider volume={volume} isMuted={isMuted} onVolumeChange={setVolume} onToggleMute={toggleMute} variant="fullscreen" />
+                  </div>
+
+                  {/* Center: prev / play / next */}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 28 }}>
+                    <button onClick={playPrevious} style={{ color: 'rgba(255,255,255,0.55)', transition: 'color 0.15s' }} onMouseEnter={(e) => e.currentTarget.style.color = '#fff'} onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.55)'}>
+                      <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" /></svg>
+                    </button>
+                    <button onClick={togglePlay} className="hover:scale-105 active:scale-95 transition-all" style={{ width: 46, height: 46, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'hsl(var(--h3))', boxShadow: '0 4px 20px hsl(var(--h4) / 0.45)' }}>
+                      {isPlaying
+                        ? <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" /></svg>
+                        : <svg className="w-5 h-5 text-white" style={{ marginLeft: 2 }} fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>}
+                    </button>
+                    <button onClick={playNext} style={{ color: 'rgba(255,255,255,0.55)', transition: 'color 0.15s' }} onMouseEnter={(e) => e.currentTarget.style.color = '#fff'} onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.55)'}>
+                      <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" /></svg>
+                    </button>
+                  </div>
+
+                  {/* Right: balance spacer */}
+                  <div style={{ flex: '0 0 200px' }} />
+                </div>
+              </div>
+            </div>
+          )}
         </div>
 
-        {/* Bottom controls */}
+        {/* Bottom controls — hidden in theater mode (theater overlay handles it) */}
         <div
           className="shrink-0 px-6 pb-5 pt-3"
-          style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.5) 0%, transparent 100%)' }}
+          style={{
+            background: 'linear-gradient(to top, rgba(0,0,0,0.5) 0%, transparent 100%)',
+            display: isTheaterMode ? 'none' : undefined,
+          }}
         >
           <div className="max-w-2xl mx-auto">
 
@@ -702,7 +1198,7 @@ export function FullScreenPlayer() {
                     src={songCover}
                     alt=""
                     className="absolute inset-0 w-full h-full object-cover"
-                    style={{ animation: 'coverFadeIn 0.35s ease-out' }}
+                    style={{ animation: 'coverFadeIn 0.45s cubic-bezier(0.16, 1, 0.3, 1)' }}
                   />
                 ) : (
                   <div className="absolute inset-0 flex items-center justify-center" style={{ background: 'rgba(255,255,255,0.06)' }}>
@@ -714,7 +1210,7 @@ export function FullScreenPlayer() {
               </div>
 
               {/* Title + artist — crossfade on track change */}
-              <div key={currentDetection?.id || 'set'} className="flex-1 min-w-0" style={{ animation: 'titleSlideIn 0.3s ease-out' }}>
+              <div key={currentDetection?.id || 'set'} className="flex-1 min-w-0" style={{ animation: 'titleSlideIn 0.4s cubic-bezier(0.16, 1, 0.3, 1)' }}>
                 <p className="text-sm truncate" style={{ color: 'rgba(255,255,255,0.9)' }}>
                   {currentDetection?.track_title || currentSet.title}
                 </p>
@@ -733,16 +1229,58 @@ export function FullScreenPlayer() {
               )}
             </div>
 
-            {/* Progress bar */}
-            <div className="relative h-[5px] rounded-full cursor-pointer group" style={{ background: 'rgba(255,255,255,0.15)' }} onClick={handleSeek}>
-              <div
-                className="absolute top-0 left-0 h-full rounded-full"
-                style={{ width: `${progress}%`, background: 'hsl(var(--h3))', transition: 'width 0.1s linear' }}
-              />
-              <div
-                className="absolute top-1/2 w-3.5 h-3.5 bg-white rounded-full shadow-md opacity-0 group-hover:opacity-100 transition-opacity"
-                style={{ left: `${progress}%`, transform: 'translate(-50%, -50%)' }}
-              />
+            {/* Progress bar with hover + storyboard */}
+            <div
+              className="relative h-[5px] rounded-full cursor-pointer group"
+              style={{ background: 'rgba(255,255,255,0.15)' }}
+              onClick={handleSeek}
+              onMouseMove={handleProgressMouseMove}
+              onMouseLeave={handleProgressMouseLeave}
+            >
+              {/* Detection chapter markers */}
+              {detections.map((d) => {
+                if (duration <= 0) return null
+                const pos = (d.start_time_seconds / duration) * 100
+                return (
+                  <div
+                    key={d.id}
+                    className="absolute top-0 h-full opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"
+                    style={{ left: `${pos}%`, width: 1.5, background: 'rgba(255,255,255,0.35)' }}
+                  />
+                )
+              })}
+              {/* Fill */}
+              <div className="absolute top-0 left-0 h-full rounded-full pointer-events-none" style={{ width: `${progress}%`, background: 'hsl(var(--h3))', transition: 'width 0.1s linear' }} />
+              {/* Hover thumb */}
+              {hoverTime !== null && (
+                <div
+                  className="absolute pointer-events-none"
+                  style={{ left: `${(hoverTime / duration) * 100}%`, top: '50%', transform: 'translate(-50%, -50%)', width: 13, height: 13, borderRadius: '50%', background: 'white', boxShadow: '0 1px 5px rgba(0,0,0,0.4)' }}
+                />
+              )}
+              {/* Hover time line */}
+              {hoverTime !== null && (
+                <div
+                  className="absolute top-0 bottom-0 w-px pointer-events-none opacity-40"
+                  style={{ left: `${(hoverTime / duration) * 100}%`, background: 'rgba(255,255,255,0.8)' }}
+                />
+              )}
+              {/* Storyboard thumbnail popup */}
+              {hoverTime !== null && thumbnailInfo && (
+                <div
+                  className="absolute pointer-events-none z-20"
+                  style={{
+                    bottom: '100%',
+                    left: Math.max(0, Math.min(hoverBarWidth - thumbnailInfo.thumbWidth, hoverX - thumbnailInfo.thumbWidth / 2)),
+                    marginBottom: 12,
+                  }}
+                >
+                  <div className="overflow-hidden rounded-lg" style={{ width: thumbnailInfo.thumbWidth, height: thumbnailInfo.thumbHeight, boxShadow: '0 8px 25px rgba(0,0,0,0.55)', border: '1px solid rgba(255,255,255,0.1)' }}>
+                    <div style={{ width: thumbnailInfo.thumbWidth, height: thumbnailInfo.thumbHeight, backgroundImage: `url(${thumbnailInfo.spriteUrl})`, backgroundPosition: `-${thumbnailInfo.bgPositionX}px -${thumbnailInfo.bgPositionY}px`, backgroundSize: storyboard ? `${storyboard.storyboardWidth * thumbnailInfo.thumbWidth}px ${storyboard.storyboardHeight * thumbnailInfo.thumbHeight}px` : undefined, backgroundRepeat: 'no-repeat' }} />
+                  </div>
+                  <p className="mt-1 text-center text-[10px] font-mono tabular-nums" style={{ color: 'rgba(255,255,255,0.5)' }}>{formatTime(hoverTime)}</p>
+                </div>
+              )}
             </div>
 
             {/* Time */}
@@ -816,12 +1354,58 @@ export function FullScreenPlayer() {
           to { opacity: 1; transform: translateY(0) scale(1); }
         }
         @keyframes coverFadeIn {
-          from { opacity: 0; transform: scale(0.92); filter: blur(4px); }
-          to { opacity: 1; transform: scale(1); filter: blur(0); }
+          from { opacity: 0; transform: scale(0.9); filter: blur(8px); }
+          to   { opacity: 1; transform: scale(1);   filter: blur(0); }
         }
         @keyframes titleSlideIn {
-          from { opacity: 0; transform: translateX(-6px); }
-          to { opacity: 1; transform: translateX(0); }
+          from { opacity: 0; transform: translateX(-6px); filter: blur(2px); }
+          to   { opacity: 1; transform: translateX(0);    filter: blur(0); }
+        }
+        @keyframes theaterExpand {
+          0%   { transform: scale(0.92); opacity: 0; filter: blur(14px); border-radius: 16px; }
+          65%  { transform: scale(1.006); opacity: 1; filter: blur(0); border-radius: 2px; }
+          100% { transform: scale(1); opacity: 1; filter: blur(0); border-radius: 0; }
+        }
+        @keyframes theaterFadeIn {
+          from { opacity: 0; transform: scale(0.92) translateX(12px); filter: blur(8px); }
+          to   { opacity: 1; transform: scale(1)    translateX(0);     filter: blur(0); }
+        }
+        @keyframes nowPlayingFlash {
+          0%   { background: rgba(0,0,0,0.6); transform: scale(1); }
+          20%  { background: hsl(var(--h3) / 0.25); transform: scale(1.026); }
+          100% { background: rgba(0,0,0,0.6); transform: scale(1); }
+        }
+        @keyframes nowPlayingTextPop {
+          0%   { opacity: 0; transform: translateY(6px); filter: blur(3px); color: hsl(var(--h3)); }
+          55%  { opacity: 1; transform: translateY(-1px); filter: blur(0); color: hsl(var(--h3)); }
+          100% { opacity: 1; transform: translateY(0); filter: blur(0); color: rgba(255,255,255,0.92); }
+        }
+        @keyframes coverPromote {
+          0%   { transform: scale(1);    filter: brightness(1) saturate(1); }
+          22%  { transform: scale(1.14); filter: brightness(1.28) saturate(1.2); }
+          100% { transform: scale(1);    filter: brightness(1) saturate(1); }
+        }
+        @keyframes labelFlash {
+          0%   { color: hsl(var(--h3) / 0.7); letter-spacing: 0.1em; }
+          30%  { color: hsl(var(--h3));        letter-spacing: 0.14em; }
+          100% { color: hsl(var(--h3) / 0.7); letter-spacing: 0.1em; }
+        }
+        @keyframes upNextEntry {
+          from { opacity: 0; transform: translateY(10px) scale(0.95); filter: blur(3px); }
+          to   { opacity: 1; transform: translateY(0)    scale(1);    filter: blur(0); }
+        }
+        @keyframes upNextExit {
+          from { opacity: 1; transform: translateY(0)     scale(1);   filter: blur(0); }
+          to   { opacity: 0; transform: translateY(-10px) scale(0.9); filter: blur(3px); }
+        }
+        @keyframes eq-bar-1 {
+          0%, 100% { height: 4px; } 50% { height: 10px; }
+        }
+        @keyframes eq-bar-2 {
+          0%, 100% { height: 8px; } 50% { height: 3px; }
+        }
+        @keyframes eq-bar-3 {
+          0%, 100% { height: 6px; } 50% { height: 10px; }
         }
       `}</style>
     </div>

--- a/src/components/player/FullScreenPlayer.tsx
+++ b/src/components/player/FullScreenPlayer.tsx
@@ -4,6 +4,7 @@ import { CoverFlowView } from './CoverFlowView'
 import { useCurrentTrackCover } from '../../hooks/useCurrentTrackCover'
 import { useAlbumColors } from '../../hooks/useAlbumColors'
 import { VolumeSlider } from '../ui/VolumeSlider'
+import { LikeButton } from '../ui/LikeButton'
 import { formatTime } from '../../lib/formatTime'
 import { getSongCoverUrl, fetchStoryboard, type StoryboardData } from '../../lib/api'
 import { getAvailableServices, ServiceIconLink } from '../../lib/services'
@@ -269,6 +270,10 @@ export function FullScreenPlayer() {
       if (isTheaterMode) {
         setTheaterMode(false)
         setShowControls(true)
+        // Exit browser fullscreen when switching to audio with theater mode
+        if (document.fullscreenElement) {
+          document.exitFullscreen().catch(() => {})
+        }
       }
     }
   }, [setVideoMode, videoStreamUrl, loadVideoStream, isTheaterMode, setTheaterMode])
@@ -762,6 +767,13 @@ export function FullScreenPlayer() {
                                     </p>
                                   )}
                                 </div>
+
+                                {/* Like button */}
+                                {primarySong && (
+                                  <div onClick={(e) => e.stopPropagation()} className="shrink-0">
+                                    <LikeButton songId={primarySong.id} size={12} />
+                                  </div>
+                                )}
                               </button>
 
                               {/* Secondary (w/) tracks — SetPage-style indented layout */}
@@ -839,6 +851,13 @@ export function FullScreenPlayer() {
                                             </p>
                                           )}
                                         </div>
+
+                                        {/* Like button */}
+                                        {secondarySong && (
+                                          <div onClick={(e) => e.stopPropagation()} className="shrink-0">
+                                            <LikeButton songId={secondarySong.id} size={10} />
+                                          </div>
+                                        )}
                                       </button>
                                     )
                                   })}
@@ -969,10 +988,22 @@ export function FullScreenPlayer() {
                             <p style={{ fontSize: 9, color: 'rgba(255,255,255,0.35)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.track_artist}</p>
                           )}
                         </div>
+                        {/* Like button for concurrent track */}
+                        {dSong && (
+                          <div style={{ flexShrink: 0 }}>
+                            <LikeButton songId={dSong.id} size={10} />
+                          </div>
+                        )}
                       </div>
                     )
                   })}
                 </div>
+                {/* Like button for main track */}
+                {song && (
+                  <div style={{ flexShrink: 0, paddingTop: 8 }}>
+                    <LikeButton songId={song.id} size={14} />
+                  </div>
+                )}
               </div>
 
               {/* Up Next — slides down inside the same card */}

--- a/src/components/ui/LikeButton.tsx
+++ b/src/components/ui/LikeButton.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect } from 'react'
+import { FiHeart } from 'react-icons/fi'
+import { FaHeart } from 'react-icons/fa'
+import { likeSong, unlikeSong, getSongLikeStatus } from '../../lib/api'
+import { useSession } from '../../lib/auth-client'
+
+interface LikeButtonProps {
+  songId: string
+  size?: number
+  className?: string
+  showCount?: boolean
+  initialCount?: number
+}
+
+export function LikeButton({ songId, size = 16, className = '', showCount = false, initialCount = 0 }: LikeButtonProps) {
+  const { data: session } = useSession()
+  const [liked, setLiked] = useState(false)
+  const [count, setCount] = useState(initialCount)
+  const [isAnimating, setIsAnimating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showParticles, setShowParticles] = useState(false)
+
+  useEffect(() => {
+    if (!session?.user || !songId) return
+
+    // Fetch like status
+    getSongLikeStatus(songId)
+      .then(res => setLiked(res.liked))
+      .catch(() => setLiked(false))
+  }, [session, songId])
+
+  const handleToggle = async (e: React.MouseEvent) => {
+    e.stopPropagation() // Prevent track click
+
+    if (!session?.user) {
+      setError('Please sign in to like songs')
+      setTimeout(() => setError(null), 2000)
+      return
+    }
+
+    if (isAnimating) return
+
+    // Optimistic update
+    const wasLiked = liked
+    const prevCount = count
+
+    setLiked(!wasLiked)
+    setCount(prev => wasLiked ? Math.max(0, prev - 1) : prev + 1)
+    setIsAnimating(true)
+
+    // Show particles only on like (not unlike)
+    if (!wasLiked) {
+      setShowParticles(true)
+      setTimeout(() => setShowParticles(false), 600)
+    }
+
+    // Animation duration
+    setTimeout(() => setIsAnimating(false), 400)
+
+    // API call in background
+    try {
+      if (wasLiked) {
+        await unlikeSong(songId)
+      } else {
+        await likeSong(songId)
+      }
+    } catch (err) {
+      console.error('Failed to toggle like:', err)
+      // Rollback optimistic update on error
+      setLiked(wasLiked)
+      setCount(prevCount)
+      setError('Failed to update like')
+      setTimeout(() => setError(null), 2000)
+    }
+  }
+
+  if (!session?.user) return null
+
+  return (
+    <button
+      onClick={handleToggle}
+      disabled={isAnimating}
+      className={`group relative flex items-center gap-1.5 ${className}`}
+      style={{
+        cursor: isAnimating ? 'default' : 'pointer',
+      }}
+      title={liked ? 'Unlike' : 'Like this track'}
+    >
+      {/* Heart icon container with animation */}
+      <span
+        className="relative flex items-center justify-center"
+        style={{
+          animation: isAnimating && liked
+            ? 'likeHeartBounce 0.4s cubic-bezier(0.34, 1.56, 0.64, 1)'
+            : undefined,
+        }}
+      >
+        {/* Particles burst effect */}
+        {showParticles && (
+          <>
+            {[...Array(6)].map((_, i) => (
+              <span
+                key={i}
+                className="absolute"
+                style={{
+                  width: 3,
+                  height: 3,
+                  borderRadius: '50%',
+                  background: 'hsl(var(--h3))',
+                  animation: `particleBurst 0.5s cubic-bezier(0, 0.5, 0.5, 1) forwards`,
+                  animationDelay: `${i * 0.02}s`,
+                  transform: `rotate(${i * 60}deg) translateY(0)`,
+                  opacity: 0,
+                }}
+              />
+            ))}
+          </>
+        )}
+
+        {/* Heart icons */}
+        {liked ? (
+          <FaHeart
+            size={size}
+            style={{
+              color: 'hsl(var(--h3))',
+              filter: 'drop-shadow(0 0 6px hsl(var(--h3) / 0.6))',
+              transition: 'filter 0.3s ease',
+            }}
+          />
+        ) : (
+          <FiHeart
+            size={size}
+            style={{
+              color: 'hsl(var(--c3))',
+              transition: 'color 0.2s ease, transform 0.2s ease',
+              transform: 'scale(1)',
+            }}
+            className="group-hover:scale-110 group-hover:!text-[hsl(var(--h3)/0.7)]"
+          />
+        )}
+      </span>
+
+      {/* Like count with smooth transition */}
+      {showCount && count > 0 && (
+        <span
+          className="text-[10px] font-mono tabular-nums"
+          style={{
+            color: liked ? 'hsl(var(--h3))' : 'hsl(var(--c3))',
+            transition: 'color 0.3s ease',
+          }}
+        >
+          {count}
+        </span>
+      )}
+
+      {/* Error tooltip */}
+      {error && (
+        <span
+          className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 rounded text-[10px] whitespace-nowrap pointer-events-none z-50"
+          style={{
+            background: 'hsl(var(--b5))',
+            color: 'hsl(var(--c1))',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+            animation: 'tooltipSlideIn 0.2s ease-out',
+          }}
+        >
+          {error}
+        </span>
+      )}
+
+      {/* Inline animations */}
+      <style>{`
+        @keyframes likeHeartBounce {
+          0% {
+            transform: scale(1);
+          }
+          25% {
+            transform: scale(1.3);
+          }
+          50% {
+            transform: scale(0.9);
+          }
+          75% {
+            transform: scale(1.1);
+          }
+          100% {
+            transform: scale(1);
+          }
+        }
+
+        @keyframes particleBurst {
+          0% {
+            transform: rotate(var(--rotation, 0deg)) translateY(0) scale(1);
+            opacity: 1;
+          }
+          100% {
+            transform: rotate(var(--rotation, 0deg)) translateY(-${size * 1.5}px) scale(0);
+            opacity: 0;
+          }
+        }
+
+        @keyframes tooltipSlideIn {
+          from {
+            opacity: 0;
+            transform: translate(-50%, 4px);
+          }
+          to {
+            opacity: 1;
+            transform: translate(-50%, 0);
+          }
+        }
+      `}</style>
+    </button>
+  )
+}

--- a/src/hooks/useAlbumColors.ts
+++ b/src/hooks/useAlbumColors.ts
@@ -1,80 +1,84 @@
-import { useState, useEffect, useRef } from 'react'
-import { Vibrant } from 'node-vibrant/browser'
+import { useState, useEffect, useRef } from "react";
+import Vibrant from "node-vibrant";
 
 export interface AlbumColors {
-  vibrant: string
-  darkVibrant: string
-  muted: string
-  darkMuted: string
-  lightVibrant: string
+  vibrant: string;
+  darkVibrant: string;
+  muted: string;
+  darkMuted: string;
+  lightVibrant: string;
 }
 
 const DEFAULT_COLORS: AlbumColors = {
-  vibrant: 'hsl(var(--h3))',
-  darkVibrant: 'hsl(var(--h4))',
-  muted: 'hsl(var(--b4))',
-  darkMuted: 'hsl(var(--b6))',
-  lightVibrant: 'hsl(var(--h2))',
-}
+  vibrant: "hsl(var(--h3))",
+  darkVibrant: "hsl(var(--h4))",
+  muted: "hsl(var(--b4))",
+  darkMuted: "hsl(var(--b6))",
+  lightVibrant: "hsl(var(--h2))",
+};
 
 // Cache extracted colors by URL to avoid re-extraction
-const colorCache = new Map<string, AlbumColors>()
+const colorCache = new Map<string, AlbumColors>();
 
 /**
  * Extract dominant colors from an album art image URL using node-vibrant.
  * Returns a palette of 5 colors that transition smoothly when the URL changes.
  */
-export function useAlbumColors(imageUrl: string | null): { colors: AlbumColors; isLoading: boolean } {
-  const [colors, setColors] = useState<AlbumColors>(DEFAULT_COLORS)
-  const [isLoading, setIsLoading] = useState(false)
-  const prevUrl = useRef<string | null>(null)
+export function useAlbumColors(imageUrl: string | null): {
+  colors: AlbumColors;
+  isLoading: boolean;
+} {
+  const [colors, setColors] = useState<AlbumColors>(DEFAULT_COLORS);
+  const [isLoading, setIsLoading] = useState(false);
+  const prevUrl = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!imageUrl || imageUrl === prevUrl.current) return
-    prevUrl.current = imageUrl
+    if (!imageUrl || imageUrl === prevUrl.current) return;
+    prevUrl.current = imageUrl;
 
     // Check cache first
-    const cached = colorCache.get(imageUrl)
+    const cached = colorCache.get(imageUrl);
     if (cached) {
-      setColors(cached)
-      return
+      setColors(cached);
+      return;
     }
 
-    setIsLoading(true)
+    setIsLoading(true);
 
     // Create a proxy image element for cross-origin access
-    const img = new Image()
-    img.crossOrigin = 'anonymous'
+    const img = new Image();
+    img.crossOrigin = "anonymous";
 
     img.onload = async () => {
       try {
-        const palette = await Vibrant.from(img).getPalette()
+        const palette = await Vibrant.from(img).getPalette();
 
         const extracted: AlbumColors = {
           vibrant: palette.Vibrant?.hex || DEFAULT_COLORS.vibrant,
           darkVibrant: palette.DarkVibrant?.hex || DEFAULT_COLORS.darkVibrant,
           muted: palette.Muted?.hex || DEFAULT_COLORS.muted,
           darkMuted: palette.DarkMuted?.hex || DEFAULT_COLORS.darkMuted,
-          lightVibrant: palette.LightVibrant?.hex || DEFAULT_COLORS.lightVibrant,
-        }
+          lightVibrant:
+            palette.LightVibrant?.hex || DEFAULT_COLORS.lightVibrant,
+        };
 
-        colorCache.set(imageUrl, extracted)
-        setColors(extracted)
+        colorCache.set(imageUrl, extracted);
+        setColors(extracted);
       } catch {
         // Extraction failed — keep current colors
       } finally {
-        setIsLoading(false)
+        setIsLoading(false);
       }
-    }
+    };
 
     img.onerror = () => {
-      setIsLoading(false)
+      setIsLoading(false);
       // Try without crossOrigin for external CDNs that don't support CORS
       // In this case we can't extract colors, so keep defaults
-    }
+    };
 
-    img.src = imageUrl
-  }, [imageUrl])
+    img.src = imageUrl;
+  }, [imageUrl]);
 
-  return { colors, isLoading }
+  return { colors, isLoading };
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -569,6 +569,32 @@ export function getSongCoverUrl(songId: string): string {
   return `${API_BASE}/songs/${songId}/cover`
 }
 
+// Song likes (authenticated)
+export async function likeSong(songId: string): Promise<{ ok: boolean; liked: boolean }> {
+  return fetchApi(`/songs/${songId}/like`, { method: 'POST' })
+}
+
+export async function unlikeSong(songId: string): Promise<{ ok: boolean; liked: boolean }> {
+  return fetchApi(`/songs/${songId}/like`, { method: 'DELETE' })
+}
+
+export async function fetchLikedSongs(page = 1): Promise<{
+  data: (Song & { liked_at: string; like_count: number; set_id: string | null })[]
+  total: number
+  page: number
+  pageSize: number
+  ok: boolean
+}> {
+  const params = new URLSearchParams()
+  if (page > 1) params.set('page', String(page))
+  const qs = params.toString()
+  return fetchApi(`/users/me/liked-songs${qs ? `?${qs}` : ''}`)
+}
+
+export async function getSongLikeStatus(songId: string): Promise<{ ok: boolean; liked: boolean }> {
+  return fetchApi(`/songs/${songId}/like-status`)
+}
+
 // Admin: Songs
 export async function fetchSongsAdmin(q?: string, page = 1): Promise<{ data: Song[]; total: number; page: number; pageSize: number }> {
   const params = new URLSearchParams()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,6 +87,7 @@ export interface Song {
   source?: string | null
   external_id?: string | null
   detection_count?: number
+  like_count?: number
   created_at?: string
   updated_at?: string
 }

--- a/src/pages/LikedSongsPage.tsx
+++ b/src/pages/LikedSongsPage.tsx
@@ -1,0 +1,263 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router'
+import { FiHeart, FiMusic, FiExternalLink } from 'react-icons/fi'
+import { fetchLikedSongs, getSongCoverUrl } from '../lib/api'
+import { getAvailableServices, ServiceIconLink } from '../lib/services'
+import { useSession } from '../lib/auth-client'
+import { Skeleton } from '../components/ui/Skeleton'
+import { LikeButton } from '../components/ui/LikeButton'
+import type { Song } from '../lib/types'
+
+type LikedSong = Song & {
+  liked_at: string
+  like_count: number
+  set_id: string | null
+}
+
+export function LikedSongsPage() {
+  const { data: session } = useSession()
+  const [songs, setSongs] = useState<LikedSong[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!session?.user) {
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    fetchLikedSongs(page)
+      .then(res => {
+        setSongs(res.data as LikedSong[])
+        setTotal(res.total)
+      })
+      .catch(err => {
+        console.error('Failed to fetch liked songs:', err)
+      })
+      .finally(() => setLoading(false))
+  }, [session, page])
+
+  const pageSize = 50
+  const totalPages = Math.ceil(total / pageSize)
+
+  // Not logged in
+  if (!session?.user) {
+    return (
+      <div className="px-6 lg:px-10 py-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="card text-center py-16">
+            <div className="flex justify-center mb-4">
+              <div
+                className="w-16 h-16 rounded-full flex items-center justify-center"
+                style={{ background: 'hsl(var(--h3) / 0.1)' }}
+              >
+                <FiHeart size={28} style={{ color: 'hsl(var(--h3))' }} />
+              </div>
+            </div>
+            <h2
+              className="text-xl mb-2"
+              style={{
+                color: 'hsl(var(--c1))',
+                fontWeight: 'var(--font-weight-bold)',
+              }}
+            >
+              Sign in to see your liked songs
+            </h2>
+            <p className="text-sm mb-6" style={{ color: 'hsl(var(--c3))' }}>
+              Like tracks as you discover them to build your personal collection
+            </p>
+            <Link to="/login" className="button-primary inline-flex items-center gap-2">
+              Sign In
+            </Link>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Loading state
+  if (loading && songs.length === 0) {
+    return (
+      <div className="px-6 lg:px-10 py-8">
+        <div className="max-w-4xl mx-auto">
+          <Skeleton className="h-8 w-48 mb-6" />
+          <div className="space-y-3">
+            {Array.from({ length: 10 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-xl" />
+            ))}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="px-6 lg:px-10 py-8">
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-6">
+          <div
+            className="w-12 h-12 rounded-full flex items-center justify-center shrink-0"
+            style={{ background: 'hsl(var(--h3) / 0.15)' }}
+          >
+            <FiHeart size={22} style={{ color: 'hsl(var(--h3))' }} />
+          </div>
+          <div>
+            <h1
+              className="text-2xl"
+              style={{
+                color: 'hsl(var(--c1))',
+                fontWeight: 'var(--font-weight-bold)',
+              }}
+            >
+              Liked Songs
+            </h1>
+            <p className="text-sm" style={{ color: 'hsl(var(--c3))' }}>
+              {total} track{total !== 1 ? 's' : ''} you've liked
+            </p>
+          </div>
+        </div>
+
+        {/* Empty state */}
+        {songs.length === 0 ? (
+          <div className="card text-center py-16">
+            <div className="flex justify-center mb-4">
+              <FiMusic size={48} style={{ color: 'hsl(var(--c3) / 0.3)' }} />
+            </div>
+            <h2
+              className="text-lg mb-2"
+              style={{
+                color: 'hsl(var(--c1))',
+                fontWeight: 'var(--font-weight-medium)',
+              }}
+            >
+              No liked songs yet
+            </h2>
+            <p className="text-sm mb-6" style={{ color: 'hsl(var(--c3))' }}>
+              Like tracks by clicking the heart icon next to any track in a set
+            </p>
+            <Link to="/" className="button-primary inline-flex items-center gap-2">
+              Browse Sets
+            </Link>
+          </div>
+        ) : (
+          <>
+            {/* Song list */}
+            <div className="space-y-2">
+              {songs.map((song) => {
+                const coverUrl = song.cover_art_r2_key
+                  ? getSongCoverUrl(song.id)
+                  : song.cover_art_url || song.lastfm_album_art
+                const serviceLinks = getAvailableServices(song as unknown as Record<string, unknown>)
+
+                return (
+                  <div key={song.id} className="card !p-3 group hover:bg-[hsl(var(--b4)/0.3)] transition-colors">
+                    <div className="flex items-center gap-3">
+                      {/* Cover art */}
+                      {coverUrl ? (
+                        <img
+                          src={coverUrl}
+                          alt=""
+                          className="w-12 h-12 rounded-lg object-cover shrink-0"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div
+                          className="w-12 h-12 rounded-lg shrink-0 flex items-center justify-center"
+                          style={{ background: 'hsl(var(--b4) / 0.4)' }}
+                        >
+                          <FiMusic size={20} style={{ color: 'hsl(var(--c3) / 0.3)' }} />
+                        </div>
+                      )}
+
+                      {/* Track info */}
+                      <div className="flex-1 min-w-0">
+                        <p
+                          className="text-sm truncate"
+                          style={{
+                            color: 'hsl(var(--c1))',
+                            fontWeight: 'var(--font-weight-medium)',
+                          }}
+                        >
+                          {song.title}
+                        </p>
+                        <div className="flex items-center gap-1.5 mt-0.5">
+                          <span className="text-xs truncate" style={{ color: 'hsl(var(--c2))' }}>
+                            {song.artist}
+                          </span>
+                          {song.label && (
+                            <>
+                              <span className="text-[10px]" style={{ color: 'hsl(var(--c3) / 0.4)' }}>
+                                ·
+                              </span>
+                              <span className="text-[10px] truncate" style={{ color: 'hsl(var(--c3))' }}>
+                                {song.label}
+                              </span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Actions */}
+                      <div className="flex items-center gap-2 shrink-0">
+                        {/* Like button */}
+                        <LikeButton songId={song.id} size={16} showCount initialCount={song.like_count} />
+
+                        {/* Service links */}
+                        {serviceLinks.length > 0 && (
+                          <div className="flex items-center gap-1.5">
+                            {serviceLinks.slice(0, 5).map(({ url, service }) => (
+                              <ServiceIconLink key={service.key} url={url} service={service} size={16} />
+                            ))}
+                          </div>
+                        )}
+
+                        {/* Go to set */}
+                        {song.set_id && (
+                          <Link
+                            to={`/sets/${song.set_id}`}
+                            className="opacity-0 group-hover:opacity-100 transition-opacity"
+                            title="Go to set"
+                          >
+                            <FiExternalLink size={16} style={{ color: 'hsl(var(--c3))' }} />
+                          </Link>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex items-center justify-center gap-2 mt-6">
+                <button
+                  onClick={() => setPage(p => Math.max(1, p - 1))}
+                  disabled={page === 1}
+                  className="button-secondary"
+                  style={{ opacity: page === 1 ? 0.5 : 1 }}
+                >
+                  Previous
+                </button>
+                <span className="text-sm px-4" style={{ color: 'hsl(var(--c3))' }}>
+                  Page {page} of {totalPages}
+                </span>
+                <button
+                  onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                  disabled={page === totalPages}
+                  className="button-secondary"
+                  style={{ opacity: page === totalPages ? 0.5 : 1 }}
+                >
+                  Next
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/stores/playerStore.ts
+++ b/src/stores/playerStore.ts
@@ -54,6 +54,10 @@ interface PlayerState {
   toggleFullScreen: () => void
   setVideoMode: (enabled: boolean) => void
   loadVideoStream: () => Promise<void>
+
+  // Theater mode
+  isTheaterMode: boolean
+  setTheaterMode: (enabled: boolean) => void
 }
 
 // Debounce position saving
@@ -80,6 +84,7 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
   isMuted: false,
   isFullScreen: false,
   isLoadingStream: false,
+  isTheaterMode: false,
   isVideoMode: false,
   videoElement: null,
   videoStreamUrl: null,
@@ -303,6 +308,8 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
   },
 
   toggleFullScreen: () => set((state) => ({ isFullScreen: !state.isFullScreen })),
+
+  setTheaterMode: (enabled) => set({ isTheaterMode: enabled }),
 
   setVideoMode: (enabled) => {
     const { videoElement, audioElement, isPlaying } = get()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,4 +32,10 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(pkg.version),
     __TURNSTILE_SITE_KEY__: JSON.stringify(process.env.TURNSTILE_SITE_KEY || ''),
   },
+  resolve: {
+    alias: {
+      // Use browser version of node-vibrant for client-side builds
+      'node-vibrant': 'node-vibrant/lib/browser.js',
+    },
+  },
 })

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -31,7 +31,7 @@ import {
 } from './routes/events'
 import { submitSetRequest, listSetRequests, approveSetRequest, rejectSetRequest } from './routes/petitions'
 import { createSourceRequest, listSourceRequests, approveSourceRequest, rejectSourceRequest } from './routes/source-requests'
-import { getSong, getSongCover, listSongsAdmin, updateSongAdmin, deleteSongAdmin, cacheSongCoverAdmin, enrichSongAdmin } from './routes/songs'
+import { getSong, getSongCover, likeSong, unlikeSong, getLikedSongs, getSongLikeStatus, listSongsAdmin, updateSongAdmin, deleteSongAdmin, cacheSongCoverAdmin, enrichSongAdmin } from './routes/songs'
 import { updateUsername } from './routes/user'
 import { handleDetectionQueue, handleFeedbackQueue, handleCoverArtQueue } from './queues/index'
 
@@ -49,6 +49,14 @@ type RouteHandler = (
   params: Record<string, string>
 ) => Promise<Response> | Response
 
+type AuthRouteHandler = (
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  params: Record<string, string>,
+  user: { id: string; role: string; name: string; email: string }
+) => Promise<Response> | Response
+
 function withAdmin(handler: RouteHandler): RouteHandler {
   return async (request, env, ctx, params) => {
     const result = await requireAdmin(request, env)
@@ -57,11 +65,11 @@ function withAdmin(handler: RouteHandler): RouteHandler {
   }
 }
 
-function withAuth(handler: RouteHandler): RouteHandler {
+function withAuth(handler: AuthRouteHandler): RouteHandler {
   return async (request, env, ctx, params) => {
     const result = await requireAuth(request, env)
     if (result instanceof Response) return result
-    return handler(request, env, ctx, params)
+    return handler(request, env, ctx, params, result.user)
   }
 }
 
@@ -90,6 +98,12 @@ router.get('/api/sets/:id/video', getSetVideo)
 // Songs (public read)
 router.get('/api/songs/:id/cover', getSongCover)
 router.get('/api/songs/:id', getSong)
+
+// Songs: User likes (authenticated)
+router.post('/api/songs/:id/like', withAuth(likeSong))
+router.delete('/api/songs/:id/like', withAuth(unlikeSong))
+router.get('/api/songs/:id/like-status', withAuth(getSongLikeStatus))
+router.get('/api/users/me/liked-songs', withAuth(getLikedSongs))
 
 // Admin: Songs
 router.get('/api/admin/songs', withAdmin(listSongsAdmin))

--- a/worker/lib/router.ts
+++ b/worker/lib/router.ts
@@ -91,11 +91,25 @@ export class Router {
 // CORS headers helper — validates origin against allowed list
 export function corsHeaders(requestOrigin?: string | null): Headers {
   const headers = new Headers()
-  // Allow the production URL, plus localhost for dev
-  const allowed = ['http://localhost:5173', 'http://localhost:4173']
-  const origin = requestOrigin && (allowed.includes(requestOrigin) || requestOrigin.endsWith('.zephyron.app') || requestOrigin.endsWith('.workers.dev') || requestOrigin.startsWith('moz-extension://') || requestOrigin.startsWith('chrome-extension://'))
-    ? requestOrigin
-    : allowed[0]
+
+  // Allowed origins for CORS
+  const allowedOrigins = [
+    'http://localhost:5173',
+    'http://localhost:4173',
+  ]
+
+  // Check if origin matches allowed patterns
+  const isAllowed = requestOrigin && (
+    allowedOrigins.includes(requestOrigin) ||
+    // Allow production domain and subdomains
+    requestOrigin.endsWith('.zephyron.app') ||
+    requestOrigin === 'https://zephyron.app' ||
+    // Allow Cloudflare Workers preview URLs (only for development)
+    (requestOrigin.endsWith('.workers.dev') && requestOrigin.includes('zephyron'))
+  )
+
+  const origin = isAllowed ? requestOrigin : allowedOrigins[0]
+
   headers.set('Access-Control-Allow-Origin', origin)
   headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS')
   headers.set('Access-Control-Allow-Headers', 'Content-Type, X-Anonymous-Id, Authorization, Range, x-api-key')

--- a/worker/routes/songs.ts
+++ b/worker/routes/songs.ts
@@ -1,4 +1,4 @@
-// Song API routes — public read + admin CRUD
+// Song API routes — public read + admin CRUD + user likes
 import { json, errorResponse } from '../lib/router'
 import type { SongRecord } from '../services/songs'
 
@@ -70,6 +70,117 @@ export async function getSongCover(
 }
 
 // ═══════════════════════════════════════════
+// User song likes (authenticated)
+// ═══════════════════════════════════════════
+
+// POST /api/songs/:id/like — Like a song
+export async function likeSong(
+  _request: Request,
+  env: Env,
+  _ctx: ExecutionContext,
+  params: Record<string, string>,
+  user: { id: string }
+): Promise<Response> {
+  const { id: songId } = params
+
+  // Verify song exists
+  const song = await env.DB.prepare('SELECT id FROM songs WHERE id = ?')
+    .bind(songId)
+    .first()
+
+  if (!song) {
+    return errorResponse('Song not found', 404)
+  }
+
+  // Insert like (ignore if already exists)
+  try {
+    await env.DB.prepare(
+      'INSERT OR IGNORE INTO user_song_likes (user_id, song_id) VALUES (?, ?)'
+    ).bind(user.id, songId).run()
+  } catch (err) {
+    console.error('[likeSong] Error:', err)
+    return errorResponse('Failed to like song', 500)
+  }
+
+  return json({ ok: true, liked: true })
+}
+
+// DELETE /api/songs/:id/like — Unlike a song
+export async function unlikeSong(
+  _request: Request,
+  env: Env,
+  _ctx: ExecutionContext,
+  params: Record<string, string>,
+  user: { id: string }
+): Promise<Response> {
+  const { id: songId } = params
+
+  await env.DB.prepare(
+    'DELETE FROM user_song_likes WHERE user_id = ? AND song_id = ?'
+  ).bind(user.id, songId).run()
+
+  return json({ ok: true, liked: false })
+}
+
+// GET /api/users/me/liked-songs — Get user's liked songs
+export async function getLikedSongs(
+  request: Request,
+  env: Env,
+  _ctx: ExecutionContext,
+  _params: Record<string, string>,
+  user: { id: string }
+): Promise<Response> {
+  const url = new URL(request.url)
+  const page = parseInt(url.searchParams.get('page') || '1')
+  const pageSize = 50
+  const offset = (page - 1) * pageSize
+
+  const [countResult, songsResult] = await Promise.all([
+    env.DB.prepare(
+      'SELECT COUNT(*) as total FROM user_song_likes WHERE user_id = ?'
+    ).bind(user.id).first<{ total: number }>(),
+
+    env.DB.prepare(`
+      SELECT
+        s.*,
+        usl.liked_at,
+        (SELECT COUNT(*) FROM user_song_likes WHERE song_id = s.id) as like_count,
+        (SELECT d.set_id FROM detections d WHERE d.song_id = s.id ORDER BY d.created_at DESC LIMIT 1) as set_id
+      FROM user_song_likes usl
+      JOIN songs s ON s.id = usl.song_id
+      WHERE usl.user_id = ?
+      ORDER BY usl.liked_at DESC
+      LIMIT ? OFFSET ?
+    `).bind(user.id, pageSize, offset).all()
+  ])
+
+  return json({
+    data: songsResult.results,
+    total: countResult?.total || 0,
+    page,
+    pageSize,
+    ok: true,
+  })
+}
+
+// GET /api/songs/:id/like-status — Check if current user has liked a song
+export async function getSongLikeStatus(
+  _request: Request,
+  env: Env,
+  _ctx: ExecutionContext,
+  params: Record<string, string>,
+  user: { id: string }
+): Promise<Response> {
+  const { id: songId } = params
+
+  const like = await env.DB.prepare(
+    'SELECT 1 FROM user_song_likes WHERE user_id = ? AND song_id = ?'
+  ).bind(user.id, songId).first()
+
+  return json({ ok: true, liked: !!like })
+}
+
+// ═══════════════════════════════════════════
 // Admin endpoints
 // ═══════════════════════════════════════════
 
@@ -86,7 +197,8 @@ export async function listSongsAdmin(
 
   let countQuery = 'SELECT COUNT(*) as total FROM songs'
   let dataQuery = `SELECT s.*,
-    (SELECT COUNT(*) FROM detections d WHERE d.song_id = s.id) as detection_count
+    (SELECT COUNT(*) FROM detections d WHERE d.song_id = s.id) as detection_count,
+    (SELECT COUNT(*) FROM user_song_likes usl WHERE usl.song_id = s.id) as like_count
     FROM songs s`
   const params: unknown[] = []
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -75,7 +75,7 @@
   // Do NOT define them here — vars override secrets on every deploy.
   "vars": {
     "BETTER_AUTH_URL": "https://zephyron.app",
-    "INVIDIOUS_BASE_URL": "https://invidious.tomasps.com"
+    "INVIDIOUS_BASE_URL": "https://invidious.zephyron.app"
   },
   // Durable Objects
   "durable_objects": {


### PR DESCRIPTION
## Summary
- **Song likes feature**: Heart button with optimistic UI, particle animations, dedicated Liked Songs page
- **Security improvements**: Fixed defu prototype pollution (HIGH), CORS hardening
- **Theater mode enhancements**: Auto-exit fullscreen when switching to audio tab
- **Admin tools**: Like count tracking, improved user management
- **Backend**: 4 new authenticated endpoints with D1 user_song_likes table

## Notable Changes Since v0.3.3-alpha
- Song liking across all track views (fullscreen theater/standard, tracklist, CoverFlow audio tab)
- LikeButton component with instant feedback, bounce + particle burst animations, background API sync with rollback
- Liked Songs page at /app/liked-songs with pagination (50/page), cover art, service links
- Backend: `POST /api/songs/:id/like`, `DELETE /api/songs/:id/unlike`, `GET /api/songs/:id/like-status`, `GET /api/songs/liked`
- Database: `user_song_likes` table with composite primary key (user_id, song_id) + indexes for performance
- Security: downgraded node-vibrant to 3.1.6, pinned defu@6.1.6, tightened CORS origin validation
- Admin: like count badges on songs tab
- Theater mode: exits browser fullscreen when switching to audio mode if theater enabled
- Audio tab: like button integrated into CoverFlowView track info