### PR TITLE
feat: scope page transitions to content only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Here's the full rewritten changelog for Zephyron. I made every entry shorter, used simple everyday words, and focused on what it means for you as a user — like faster listening or easier navigation. [keepachangelog](https://keepachangelog.com/en/1.1.0/)
 
+## [0.4.2-alpha] - 2026-04-17
+
+### Improved
+- Page transitions no longer animate persistent UI elements — the profile sidebar stays in place when switching tabs; only the content area fades in.
+
+### Fixed
+- TypeScript build errors from unused imports and stub code in the admin Sets Upload tab and Set page.
+
 ## [0.4.1-alpha] - 2026-04-15
 
 ### New

--- a/src/components/layout/PageTransition.tsx
+++ b/src/components/layout/PageTransition.tsx
@@ -22,12 +22,12 @@ const ANIMATIONS: Record<AnimationKey, string> = {
 }
 
 export function PageTransition() {
-  const { key, pathname } = useLocation()
+  const { pathname } = useLocation()
   const navType = useNavigationType()
   const animation = ANIMATIONS[resolveAnimation(pathname, navType)]
 
   return (
-    <div key={key} style={{ animation }}>
+    <div key={pathname} style={{ animation }}>
       <Outlet />
     </div>
   )

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -489,7 +489,7 @@ export function ProfilePage() {
 
       {/* Main content */}
       <main className="flex-1 px-6 lg:px-10 py-6">
-        <div className="max-w-5xl mx-auto space-y-5">
+        <div key={activeTab} className="max-w-5xl mx-auto space-y-5" style={{ animation: 'tab-enter 0.18s var(--ease-spring) both' }}>
           {/* Quick Stats Section */}
           {currentMonthStats && (
             <div className="card">


### PR DESCRIPTION
## Summary
- `PageTransition` now keys on `pathname` instead of `location.key`, so navigations that only change query params (e.g. profile tab switches via `?tab=`) no longer re-animate the entire page including the sidebar
- `ProfilePage` wraps only the main content `<div>` with `key={activeTab}` and a `tab-enter` animation, so tab switching still feels responsive — just without animating the sidebar
- Adds `CHANGELOG.md` entry for `0.4.2-alpha`

## Test plan
- [ ] Navigate between profile tabs — sidebar should stay static, only content fades in
- [ ] Navigate between different routes (e.g. Browse → Set page) — full page transition should still play
- [ ] Browser back/forward — back animation still triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)