### PR TITLE
feat: account deletion hotlink + admin create user

### DIFF
--- a/docs/superpowers/specs/2026-04-25-admin-create-user-design.md
+++ b/docs/superpowers/specs/2026-04-25-admin-create-user-design.md
@@ -1,0 +1,109 @@
+# Admin Create User — Design Spec
+
+**Date:** 2026-04-25
+**Status:** Approved
+
+## Context
+
+The admin Users tab (`src/components/admin/UsersTab.tsx`) supports all user management actions (ban, delete, impersonate, set password, etc.) but has no way to create new users. Admins need this to onboard users directly without requiring them to self-register with an invite code.
+
+## Goals
+
+1. "Create User" button in the UsersTab header that opens a modal form.
+2. Admin-created users bypass the invite code requirement.
+3. New user appears in the list immediately on success.
+
+---
+
+## UI: `UsersTab.tsx`
+
+### Header row change
+
+Add a "Create User" button to the right of the existing search + user count row:
+
+```
+[ 🔍 Search by email… ]    [ Create User ]    42 users
+```
+
+The button uses the existing `Button` component with `variant="primary"` and `size="sm"`.
+
+### Create User modal
+
+Triggered by the "Create User" button. Uses the existing `Modal` component with title "Create User".
+
+**Fields:**
+- **Name** — text input, required, placeholder "Full name"
+- **Email** — email input, required, placeholder "email@example.com"
+- **Password** — password input, required, placeholder "Min. 8 characters", `autoComplete="new-password"`
+- **Role** — pill toggle: `user` (default) / `admin`, same pill pattern as the ban expiry duration selector already in the file
+
+**Actions:**
+- "Create User" primary button — disabled while any required field is empty, password < 8 chars, or request in flight
+- Cancel ghost button
+
+**Success:** close modal, reset form, prepend new user to `users` state, increment `total`, show toast "User created successfully".
+
+**Error:** show inline error message inside the modal (same style as the ban/delete modals).
+
+---
+
+## API
+
+Uses the existing Better Auth admin client method already available in the project:
+
+```typescript
+authClient.admin.createUser({
+  name,
+  email,
+  password,
+  role: role as 'user' | 'admin',
+})
+```
+
+No new worker endpoints needed — this goes through Better Auth's admin API directly.
+
+---
+
+## Backend: Invite code hook bypass
+
+**File:** `worker/lib/auth.ts`
+
+The `databaseHooks.user.create.before` hook currently throws `'Invite code is required'` if no invite code is present. Admin-created users won't have one.
+
+**Change:** Make the invite code validation conditional — only run if an invite code is present. Self-registration always sends one (enforced by the register form UI and the `inviteCode` field being required there), so removing the hard throw for absence does not weaken that path.
+
+**Before:**
+```typescript
+const inviteCode = (user as any).invite_code || (user as any).inviteCode
+if (!inviteCode) {
+  throw new Error('Invite code is required')
+}
+// ... validate code ...
+```
+
+**After:**
+```typescript
+const inviteCode = (user as any).invite_code || (user as any).inviteCode
+if (inviteCode) {
+  // validate and consume invite code as before
+}
+```
+
+The `after` hook (which increments `used_count`) is already guarded by `if (inviteCode)` — no change needed there.
+
+---
+
+## Files to create/modify
+
+| File | Change |
+|------|--------|
+| `src/components/admin/UsersTab.tsx` | Add "Create User" button, modal, form state, and `handleCreateUser` action |
+| `worker/lib/auth.ts` | Make invite code validation conditional (skip if no code present) |
+
+---
+
+## Out of scope
+
+- Email verification for admin-created accounts (Better Auth sends a verification email if email verification is enabled; that's existing behaviour and not changed)
+- Sending a welcome/credentials email to the new user — separate feature
+- Bulk user creation

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { LoginPage } from './pages/LoginPage'
 import { RegisterPage } from './pages/RegisterPage'
 import { AboutPage } from './pages/AboutPage'
 import { PrivacyPage } from './pages/PrivacyPage'
+import { DeleteAccountPage } from './pages/DeleteAccountPage'
 import { TermsPage } from './pages/TermsPage'
 import { TwoFactorPage } from './pages/TwoFactorPage'
 import { ResetPasswordPage } from './pages/ResetPasswordPage'
@@ -134,6 +135,7 @@ function App() {
         <Route path="2fa" element={<TwoFactorPage />} />
         <Route path="about" element={<AboutPage />} />
         <Route path="privacy" element={<PrivacyPage />} />
+        <Route path="delete-account" element={<DeleteAccountPage />} />
         <Route path="terms" element={<TermsPage />} />
         <Route path="device" element={<DevicePage />} />
 

--- a/src/components/admin/UsersTab.tsx
+++ b/src/components/admin/UsersTab.tsx
@@ -465,6 +465,7 @@ export function UsersTab() {
         email: createEmail.trim(),
         password: createPassword,
         role: createRole,
+        data: { skip_invite_check: true },
       });
       if (res.error) {
         setCreateError(res.error.message ?? "Failed to create user");
@@ -493,6 +494,8 @@ export function UsersTab() {
       } else {
         setCreateError("User created but response was unexpected. Refresh to see changes.");
       }
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : "Failed to create user");
     } finally {
       setIsCreating(false);
     }

--- a/src/components/admin/UsersTab.tsx
+++ b/src/components/admin/UsersTab.tsx
@@ -26,7 +26,8 @@ type ActionModal =
   | { type: "ban"; user: User }
   | { type: "delete"; user: User }
   | { type: "revoke"; user: User }
-  | { type: "set-password"; user: User };
+  | { type: "set-password"; user: User }
+  | { type: "create" };
 
 const BAN_EXPIRY_OPTIONS = [
   { label: "Permanent", value: "" },
@@ -256,6 +257,12 @@ export function UsersTab() {
   const [banExpiry, setBanExpiry] = useState("");
   // Set password form state
   const [newPassword, setNewPassword] = useState("");
+  // Create user form state
+  const [createName, setCreateName] = useState("");
+  const [createEmail, setCreateEmail] = useState("");
+  const [createPassword, setCreatePassword] = useState("");
+  const [createRole, setCreateRole] = useState<"user" | "admin">("user");
+  const [createError, setCreateError] = useState("");
 
   const pageSize = 20;
 
@@ -448,6 +455,42 @@ export function UsersTab() {
     });
   };
 
+  const handleCreateUser = async () => {
+    setCreateError("");
+    const res = await authClient.admin.createUser({
+      name: createName.trim(),
+      email: createEmail.trim(),
+      password: createPassword,
+      role: createRole,
+    });
+    if (res.error) {
+      setCreateError(res.error.message ?? "Failed to create user");
+      return;
+    }
+    if ((res.data as any)?.user) {
+      const u = (res.data as any).user;
+      const newUser: User = {
+        id: u.id,
+        name: u.name,
+        email: u.email,
+        role: u.role ?? createRole,
+        banned: false,
+        banReason: null,
+        reputation: 0,
+        createdAt: u.createdAt as unknown as string,
+      };
+      setUsers((prev) => [newUser, ...prev]);
+      setTotal((t) => t + 1);
+    }
+    setModal(null);
+    setCreateName("");
+    setCreateEmail("");
+    setCreatePassword("");
+    setCreateRole("user");
+    setCreateError("");
+    showToast("User created successfully");
+  };
+
   const totalPages = Math.ceil(total / pageSize);
 
   // ── Render ───────────────────────────────────────────────────────────────────
@@ -489,8 +532,15 @@ export function UsersTab() {
             }}
           />
         </div>
+        <Button
+          size="sm"
+          variant="primary"
+          onClick={() => setModal({ type: "create" })}
+        >
+          Create User
+        </Button>
         <p
-          className="text-sm ml-auto shrink-0"
+          className="text-sm shrink-0"
           style={{ color: "hsl(var(--c3))" }}
         >
           {total} user{total !== 1 ? "s" : ""}
@@ -877,6 +927,113 @@ export function UsersTab() {
               }}
             >
               Set Password
+            </Button>
+          </div>
+        </div>
+      </Modal>
+      {/* ── Create user modal ─────────────────────────────────────────────── */}
+      <Modal
+        isOpen={modal?.type === "create"}
+        onClose={() => {
+          setModal(null);
+          setCreateName("");
+          setCreateEmail("");
+          setCreatePassword("");
+          setCreateRole("user");
+          setCreateError("");
+        }}
+        title="Create User"
+      >
+        <div className="flex flex-col gap-4">
+          <Input
+            label="Name"
+            placeholder="Full name"
+            value={createName}
+            onChange={(e) => setCreateName(e.target.value)}
+            autoComplete="off"
+          />
+          <Input
+            label="Email"
+            type="email"
+            placeholder="email@example.com"
+            value={createEmail}
+            onChange={(e) => setCreateEmail(e.target.value)}
+            autoComplete="off"
+          />
+          <Input
+            label="Password"
+            type="password"
+            placeholder="Min. 8 characters"
+            value={createPassword}
+            onChange={(e) => setCreatePassword(e.target.value)}
+            autoComplete="new-password"
+          />
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              className="text-sm font-[var(--font-weight-medium)]"
+              style={{ color: "hsl(var(--c2))" }}
+            >
+              Role
+            </label>
+            <div className="flex gap-2">
+              {(["user", "admin"] as const).map((r) => (
+                <button
+                  key={r}
+                  type="button"
+                  onClick={() => setCreateRole(r)}
+                  className="px-3 py-1.5 rounded-lg text-xs transition-all cursor-pointer capitalize"
+                  style={{
+                    background:
+                      createRole === r
+                        ? "hsl(var(--h3) / 0.15)"
+                        : "hsl(var(--b4) / 0.4)",
+                    color:
+                      createRole === r
+                        ? "hsl(var(--h3))"
+                        : "hsl(var(--c2))",
+                    boxShadow:
+                      createRole === r
+                        ? "inset 0 0 0 1px hsl(var(--h3) / 0.4)"
+                        : "none",
+                  }}
+                >
+                  {r}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {createError && (
+            <p className="text-xs" style={{ color: "hsl(0, 60%, 65%)" }}>
+              {createError}
+            </p>
+          )}
+
+          <div className="flex gap-2 justify-end pt-1">
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setModal(null);
+                setCreateName("");
+                setCreateEmail("");
+                setCreatePassword("");
+                setCreateRole("user");
+                setCreateError("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              disabled={
+                !createName.trim() ||
+                !createEmail.trim() ||
+                createPassword.length < 8
+              }
+              onClick={handleCreateUser}
+            >
+              Create User
             </Button>
           </div>
         </div>

--- a/src/components/admin/UsersTab.tsx
+++ b/src/components/admin/UsersTab.tsx
@@ -263,6 +263,7 @@ export function UsersTab() {
   const [createPassword, setCreatePassword] = useState("");
   const [createRole, setCreateRole] = useState<"user" | "admin">("user");
   const [createError, setCreateError] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
 
   const pageSize = 20;
 
@@ -457,38 +458,44 @@ export function UsersTab() {
 
   const handleCreateUser = async () => {
     setCreateError("");
-    const res = await authClient.admin.createUser({
-      name: createName.trim(),
-      email: createEmail.trim(),
-      password: createPassword,
-      role: createRole,
-    });
-    if (res.error) {
-      setCreateError(res.error.message ?? "Failed to create user");
-      return;
+    setIsCreating(true);
+    try {
+      const res = await authClient.admin.createUser({
+        name: createName.trim(),
+        email: createEmail.trim(),
+        password: createPassword,
+        role: createRole,
+      });
+      if (res.error) {
+        setCreateError(res.error.message ?? "Failed to create user");
+        return;
+      }
+      if ((res.data as any)?.user) {
+        const newUser: User = {
+          id: (res.data as any).user.id,
+          name: (res.data as any).user.name,
+          email: (res.data as any).user.email,
+          role: (res.data as any).user.role ?? createRole,
+          banned: false,
+          banReason: null,
+          reputation: 0,
+          createdAt: (res.data as any).user.createdAt as unknown as string,
+        };
+        setUsers((prev) => [newUser, ...prev]);
+        setTotal((t) => t + 1);
+        setModal(null);
+        setCreateName("");
+        setCreateEmail("");
+        setCreatePassword("");
+        setCreateRole("user");
+        setCreateError("");
+        showToast("User created successfully");
+      } else {
+        setCreateError("User created but response was unexpected. Refresh to see changes.");
+      }
+    } finally {
+      setIsCreating(false);
     }
-    if ((res.data as any)?.user) {
-      const u = (res.data as any).user;
-      const newUser: User = {
-        id: u.id,
-        name: u.name,
-        email: u.email,
-        role: u.role ?? createRole,
-        banned: false,
-        banReason: null,
-        reputation: 0,
-        createdAt: u.createdAt as unknown as string,
-      };
-      setUsers((prev) => [newUser, ...prev]);
-      setTotal((t) => t + 1);
-    }
-    setModal(null);
-    setCreateName("");
-    setCreateEmail("");
-    setCreatePassword("");
-    setCreateRole("user");
-    setCreateError("");
-    showToast("User created successfully");
   };
 
   const totalPages = Math.ceil(total / pageSize);
@@ -1029,11 +1036,12 @@ export function UsersTab() {
               disabled={
                 !createName.trim() ||
                 !createEmail.trim() ||
-                createPassword.length < 8
+                createPassword.length < 8 ||
+                isCreating
               }
               onClick={handleCreateUser}
             >
-              Create User
+              {isCreating ? "Creating…" : "Create User"}
             </Button>
           </div>
         </div>

--- a/src/pages/DeleteAccountPage.tsx
+++ b/src/pages/DeleteAccountPage.tsx
@@ -56,7 +56,7 @@ export function DeleteAccountPage() {
       </header>
 
       {/* Content */}
-      <main className="flex-1 px-5 sm:px-8 py-12 max-w-3xl mx-auto w-full">
+      <main className="flex-1 px-5 sm:px-8 lg:px-16 py-12 max-w-3xl mx-auto w-full">
         {!session ? (
           <LoggedOutState />
         ) : (
@@ -72,12 +72,12 @@ export function DeleteAccountPage() {
       </main>
 
       {/* Footer */}
-      <footer className="px-5 sm:px-8 py-5" style={{ borderTop: '1px solid hsl(var(--b4) / 0.3)' }}>
+      <footer className="px-5 sm:px-8 py-5 border-t border-border">
         <div className="max-w-3xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-3">
-          <p className="text-xs" style={{ color: 'hsl(var(--c3))' }}>&copy; {new Date().getFullYear()} Zephyron</p>
+          <p className="text-xs text-text-muted">&copy; {new Date().getFullYear()} Zephyron</p>
           <div className="flex items-center gap-4 text-xs">
-            <Link to="/privacy" className="no-underline transition-colors" style={{ color: 'hsl(var(--c3))' }}>Privacy</Link>
-            <Link to="/terms" className="no-underline transition-colors" style={{ color: 'hsl(var(--c3))' }}>Terms</Link>
+            <Link to="/privacy" className="text-text-muted hover:text-text-primary transition-colors no-underline">Privacy</Link>
+            <Link to="/terms" className="text-text-muted hover:text-text-primary transition-colors no-underline">Terms</Link>
           </div>
         </div>
       </footer>
@@ -178,6 +178,7 @@ function LoggedInState({
 
         <input
           type="text"
+          aria-label="Type DELETE to confirm account deletion"
           value={confirmText}
           onChange={(e) => onConfirmChange(e.target.value)}
           placeholder="Type DELETE to confirm"
@@ -198,6 +199,7 @@ function LoggedInState({
 
         <div className="flex items-center gap-3">
           <button
+            type="button"
             onClick={onDelete}
             disabled={!confirmed || loading}
             className="px-4 h-[var(--button-height)] rounded-[var(--button-radius)] text-sm font-[var(--font-weight-medium)] transition-all active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"

--- a/src/pages/DeleteAccountPage.tsx
+++ b/src/pages/DeleteAccountPage.tsx
@@ -151,10 +151,10 @@ function LoggedInState({
         <ul className="text-sm space-y-1.5 list-none p-0 m-0" style={{ color: 'hsl(var(--c2))' }}>
           {[
             'Your account and login credentials',
-            'Listening history and session data',
-            'Annotations and votes',
-            'Playlists',
+            'Listening history and playlists',
+            'Liked songs',
             'Profile picture and banner',
+            'Annotations and votes (anonymised, not removed)',
           ].map((item) => (
             <li key={item} className="flex items-center gap-2">
               <span style={{ color: 'hsl(0, 60%, 60%)' }}>×</span>

--- a/src/pages/DeleteAccountPage.tsx
+++ b/src/pages/DeleteAccountPage.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router'
+import { useSession, authClient } from '../lib/auth-client'
+import { Logo } from '../components/ui/Logo'
+
+export function DeleteAccountPage() {
+  const { data: session, isPending } = useSession()
+  const navigate = useNavigate()
+  const [confirmText, setConfirmText] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (isPending) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-surface">
+        <div className="w-8 h-8 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  const handleDelete = async () => {
+    setError(null)
+    setLoading(true)
+    try {
+      const res = await fetch('/api/user/me', { method: 'DELETE' })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setError((body as any).error || 'Failed to delete account. Please try again.')
+        setLoading(false)
+        return
+      }
+      await authClient.signOut()
+      navigate('/login?deleted=1', { replace: true })
+    } catch {
+      setError('Something went wrong. Please try again.')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-surface flex flex-col">
+      {/* Nav */}
+      <header className="flex items-center justify-between px-5 sm:px-8 py-5">
+        <Link to="/" className="flex items-center gap-2.5 no-underline">
+          <Logo size={32} />
+          <span className="text-lg font-semibold text-text-primary tracking-tight">Zephyron</span>
+        </Link>
+        <div className="flex items-center gap-4">
+          <Link to="/about" className="text-sm text-text-secondary hover:text-text-primary transition-colors no-underline">About</Link>
+          {session ? (
+            <Link to="/app/settings?tab=account" className="text-sm text-text-secondary hover:text-text-primary transition-colors no-underline">Settings</Link>
+          ) : (
+            <Link to="/login?redirect=/delete-account" className="text-sm text-text-secondary hover:text-text-primary transition-colors no-underline">Sign In</Link>
+          )}
+        </div>
+      </header>
+
+      {/* Content */}
+      <main className="flex-1 px-5 sm:px-8 py-12 max-w-3xl mx-auto w-full">
+        {!session ? (
+          <LoggedOutState />
+        ) : (
+          <LoggedInState
+            userName={session.user.name}
+            confirmText={confirmText}
+            onConfirmChange={setConfirmText}
+            onDelete={handleDelete}
+            loading={loading}
+            error={error}
+          />
+        )}
+      </main>
+
+      {/* Footer */}
+      <footer className="px-5 sm:px-8 py-5" style={{ borderTop: '1px solid hsl(var(--b4) / 0.3)' }}>
+        <div className="max-w-3xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-3">
+          <p className="text-xs" style={{ color: 'hsl(var(--c3))' }}>&copy; {new Date().getFullYear()} Zephyron</p>
+          <div className="flex items-center gap-4 text-xs">
+            <Link to="/privacy" className="no-underline transition-colors" style={{ color: 'hsl(var(--c3))' }}>Privacy</Link>
+            <Link to="/terms" className="no-underline transition-colors" style={{ color: 'hsl(var(--c3))' }}>Terms</Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+function LoggedOutState() {
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-2" style={{ color: 'hsl(var(--c1))' }}>Delete Account</h1>
+      <p className="text-sm mb-8" style={{ color: 'hsl(var(--c3))' }}>Permanently remove your Zephyron account and all associated data.</p>
+
+      <div
+        className="rounded-xl p-5 space-y-4"
+        style={{
+          background: 'hsl(var(--b5))',
+          boxShadow: 'var(--card-border), var(--card-shadow)',
+        }}
+      >
+        <p className="text-sm" style={{ color: 'hsl(var(--c2))' }}>
+          To delete your account, you need to be signed in. Please sign in first and you'll be brought back here to complete the process.
+        </p>
+        <Link
+          to="/login?redirect=/delete-account"
+          className="inline-flex items-center justify-center px-4 h-[var(--button-height)] rounded-[var(--button-radius)] text-sm font-[var(--font-weight-medium)] no-underline transition-all active:scale-[0.98]"
+          style={{ background: 'hsl(var(--h3))', color: '#fff' }}
+        >
+          Sign In to Continue
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+function LoggedInState({
+  userName,
+  confirmText,
+  onConfirmChange,
+  onDelete,
+  loading,
+  error,
+}: {
+  userName: string
+  confirmText: string
+  onConfirmChange: (v: string) => void
+  onDelete: () => void
+  loading: boolean
+  error: string | null
+}) {
+  const confirmed = confirmText === 'DELETE'
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-2" style={{ color: 'hsl(var(--c1))' }}>Delete Account</h1>
+      <p className="text-sm mb-8" style={{ color: 'hsl(var(--c3))' }}>
+        Signed in as <span style={{ color: 'hsl(var(--c1))' }}>{userName}</span>
+      </p>
+
+      {/* What gets deleted */}
+      <div
+        className="rounded-xl p-5 mb-5 space-y-3"
+        style={{
+          background: 'hsl(var(--b5))',
+          boxShadow: 'var(--card-border), var(--card-shadow)',
+        }}
+      >
+        <h2 className="text-sm font-[var(--font-weight-medium)]" style={{ color: 'hsl(var(--c1))' }}>
+          What will be deleted
+        </h2>
+        <ul className="text-sm space-y-1.5 list-none p-0 m-0" style={{ color: 'hsl(var(--c2))' }}>
+          {[
+            'Your account and login credentials',
+            'Listening history and session data',
+            'Annotations and votes',
+            'Playlists',
+            'Profile picture and banner',
+          ].map((item) => (
+            <li key={item} className="flex items-center gap-2">
+              <span style={{ color: 'hsl(0, 60%, 60%)' }}>×</span>
+              {item}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Danger zone */}
+      <div
+        className="rounded-xl p-5 space-y-4"
+        style={{
+          background: 'hsl(0, 60%, 50% / 0.05)',
+          boxShadow: 'inset 0 0 0 1px hsl(0, 60%, 50% / 0.2)',
+        }}
+      >
+        <p className="text-sm" style={{ color: 'hsl(var(--c2))' }}>
+          This action is <strong style={{ color: 'hsl(0, 60%, 65%)' }}>permanent and cannot be undone</strong>. Type <code className="px-1 py-0.5 rounded text-xs" style={{ background: 'hsl(var(--b3))', color: 'hsl(var(--c1))' }}>DELETE</code> to confirm.
+        </p>
+
+        <input
+          type="text"
+          value={confirmText}
+          onChange={(e) => onConfirmChange(e.target.value)}
+          placeholder="Type DELETE to confirm"
+          className="w-full px-3 py-2 rounded-[var(--button-radius)] text-sm focus:outline-none transition-all"
+          style={{
+            background: 'hsl(var(--b4) / 0.4)',
+            color: 'hsl(var(--c1))',
+            boxShadow: confirmed ? 'inset 0 0 0 1px hsl(0, 60%, 50% / 0.5)' : 'inset 0 0 0 1px hsl(var(--b4) / 0.4)',
+          }}
+          disabled={loading}
+          autoComplete="off"
+          spellCheck={false}
+        />
+
+        {error && (
+          <p className="text-xs" style={{ color: 'hsl(0, 60%, 65%)' }}>{error}</p>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            onClick={onDelete}
+            disabled={!confirmed || loading}
+            className="px-4 h-[var(--button-height)] rounded-[var(--button-radius)] text-sm font-[var(--font-weight-medium)] transition-all active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+            style={{
+              background: confirmed ? 'hsl(0, 60%, 45%)' : 'hsl(0, 60%, 45% / 0.4)',
+              color: '#fff',
+            }}
+          >
+            {loading ? 'Deleting…' : 'Delete My Account'}
+          </button>
+          <Link
+            to="/app/settings?tab=account"
+            className="text-sm no-underline transition-colors"
+            style={{ color: 'hsl(var(--c3))' }}
+          >
+            Cancel
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useSearchParams, Link } from 'react-router'
+import { useSearchParams, useNavigate, Link } from 'react-router'
 import { useSession, authClient, getSession } from '../lib/auth-client'
 import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
@@ -851,6 +851,7 @@ function ApiKeysSection() {
 function AccountTab() {
   const { data: session } = useSession()
   const user = session?.user as any
+  const navigate = useNavigate()
   const [signingOut, setSigningOut] = useState(false)
 
   const handleSignOutAll = async () => {
@@ -908,11 +909,9 @@ function AccountTab() {
         <p className="text-xs text-text-muted">
           Permanently delete your account and all associated data. This action cannot be undone.
         </p>
-        <Link to="/delete-account" className="no-underline">
-          <Button variant="danger" size="sm">
-            Delete Account
-          </Button>
-        </Link>
+        <Button variant="danger" size="sm" onClick={() => navigate('/delete-account')}>
+          Delete Account
+        </Button>
       </div>
     </div>
   )

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -906,11 +906,13 @@ function AccountTab() {
       <div className="bg-surface-raised border border-danger/20 rounded-xl p-5 space-y-3">
         <h3 className="text-sm font-semibold text-danger">Danger Zone</h3>
         <p className="text-xs text-text-muted">
-          Account deletion is not yet available. Contact support if you need to delete your account.
+          Permanently delete your account and all associated data. This action cannot be undone.
         </p>
-        <Button variant="danger" size="sm" disabled>
-          Delete Account
-        </Button>
+        <Link to="/delete-account" className="no-underline">
+          <Button variant="danger" size="sm">
+            Delete Account
+          </Button>
+        </Link>
       </div>
     </div>
   )

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -33,7 +33,7 @@ import {
 import { submitSetRequest, listSetRequests, approveSetRequest, rejectSetRequest } from './routes/petitions'
 import { createSourceRequest, listSourceRequests, approveSourceRequest, rejectSourceRequest } from './routes/source-requests'
 import { getSong, getSongCover, likeSong, unlikeSong, getLikedSongs, getSongLikeStatus, listSongsAdmin, updateSongAdmin, deleteSongAdmin, cacheSongCoverAdmin, enrichSongAdmin } from './routes/songs'
-import { updateUsername } from './routes/user'
+import { updateUsername, deleteCurrentUser } from './routes/user'
 import { uploadAvatar, uploadBanner, deleteBanner, updateProfileSettings, getPublicProfile } from './routes/profile'
 import { getStats } from './routes/stats'
 import { getBadges } from './routes/badges'
@@ -186,6 +186,7 @@ router.post('/api/sets/:id/request-source', withAuth(createSourceRequest))
 
 // User profile
 router.patch('/api/user/username', updateUsername)
+router.delete('/api/user/me', deleteCurrentUser)
 
 // Profile routes
 router.post('/api/profile/avatar/upload', uploadAvatar)

--- a/worker/lib/auth.ts
+++ b/worker/lib/auth.ts
@@ -157,27 +157,25 @@ export function createAuth(env: Env) {
           before: async (user) => {
             // Validate invite code during registration
             const inviteCode = (user as any).invite_code || (user as any).inviteCode
-            if (!inviteCode) {
-              throw new Error('Invite code is required')
-            }
+            if (inviteCode) {
+              // Check invite code validity (do NOT consume yet — wait for successful creation)
+              const code = await env.DB.prepare(
+                'SELECT id, max_uses, used_count, expires_at FROM invite_codes WHERE code = ?'
+              )
+                .bind(inviteCode)
+                .first<{ id: string; max_uses: number; used_count: number; expires_at: string | null }>()
 
-            // Check invite code validity (do NOT consume yet — wait for successful creation)
-            const code = await env.DB.prepare(
-              'SELECT id, max_uses, used_count, expires_at FROM invite_codes WHERE code = ?'
-            )
-              .bind(inviteCode)
-              .first<{ id: string; max_uses: number; used_count: number; expires_at: string | null }>()
+              if (!code) {
+                throw new Error('Invalid invite code')
+              }
 
-            if (!code) {
-              throw new Error('Invalid invite code')
-            }
+              if (code.max_uses > 0 && code.used_count >= code.max_uses) {
+                throw new Error('Invite code has been fully used')
+              }
 
-            if (code.max_uses > 0 && code.used_count >= code.max_uses) {
-              throw new Error('Invite code has been fully used')
-            }
-
-            if (code.expires_at && new Date(code.expires_at) < new Date()) {
-              throw new Error('Invite code has expired')
+              if (code.expires_at && new Date(code.expires_at) < new Date()) {
+                throw new Error('Invite code has expired')
+              }
             }
 
             return {

--- a/worker/lib/auth.ts
+++ b/worker/lib/auth.ts
@@ -156,8 +156,16 @@ export function createAuth(env: Env) {
         create: {
           before: async (user) => {
             // Validate invite code during registration
+            // Admin-created users pass data.skip_invite_check to bypass this requirement.
+            // Self-registration must always supply an invite code.
+            const skipInviteCheck = (user as any).skip_invite_check === true
             const inviteCode = (user as any).invite_code || (user as any).inviteCode
-            if (inviteCode) {
+
+            if (!skipInviteCheck) {
+              if (!inviteCode) {
+                throw new Error('Invite code is required')
+              }
+
               // Check invite code validity (do NOT consume yet — wait for successful creation)
               const code = await env.DB.prepare(
                 'SELECT id, max_uses, used_count, expires_at FROM invite_codes WHERE code = ?'

--- a/worker/routes/user.ts
+++ b/worker/routes/user.ts
@@ -58,3 +58,37 @@ export async function updateUsername(
 
   return json({ ok: true, username })
 }
+
+/**
+ * DELETE /api/user/me
+ * Deletes the authenticated user's account and all associated R2 assets.
+ */
+export async function deleteCurrentUser(
+  request: Request,
+  env: Env,
+  _ctx: ExecutionContext,
+  _params: Record<string, string>
+): Promise<Response> {
+  const authResult = await requireAuth(request, env)
+  if (authResult instanceof Response) return authResult
+
+  const { user } = authResult
+
+  // Best-effort: delete R2 assets before removing user record
+  await Promise.allSettled([
+    env.AVATARS.delete(`${user.id}/avatar.webp`),
+    env.AVATARS.delete(`${user.id}/banner.webp`),
+  ])
+
+  const auth = createAuth(env)
+  const result = await (auth.api as any).removeUser({
+    body: { userId: user.id },
+    headers: request.headers,
+  })
+
+  if (!result) {
+    return errorResponse('Failed to delete account', 500)
+  }
+
+  return json({ ok: true })
+}

--- a/worker/routes/user.ts
+++ b/worker/routes/user.ts
@@ -74,10 +74,17 @@ export async function deleteCurrentUser(
 
   const { user } = authResult
 
-  // Best-effort: delete R2 assets before removing user record
+  // Best-effort: delete R2 assets and orphaned user data before removing user record
+  const userId = user.id
   await Promise.allSettled([
-    env.AVATARS.delete(`${user.id}/avatar.webp`),
-    env.AVATARS.delete(`${user.id}/banner.webp`),
+    env.AVATARS.delete(`${userId}/avatar-small.webp`),
+    env.AVATARS.delete(`${userId}/avatar-large.webp`),
+    env.AVATARS.delete(`${userId}/banner.webp`),
+    env.DB.prepare('DELETE FROM listen_history WHERE user_id = ?').bind(userId).run(),
+    env.DB.prepare('DELETE FROM playlists WHERE user_id = ?').bind(userId).run(),
+    env.DB.prepare('DELETE FROM user_song_likes WHERE user_id = ?').bind(userId).run(),
+    env.DB.prepare('UPDATE annotations SET user_id = NULL WHERE user_id = ?').bind(userId).run(),
+    env.DB.prepare('UPDATE votes SET user_id = NULL WHERE user_id = ?').bind(userId).run(),
   ])
 
   const auth = createAuth(env)

--- a/worker/routes/user.ts
+++ b/worker/routes/user.ts
@@ -81,12 +81,17 @@ export async function deleteCurrentUser(
   ])
 
   const auth = createAuth(env)
-  const result = await (auth.api as any).removeUser({
+  // `auth.api` type does not expose admin-plugin endpoints without explicit widening.
+  // The admin plugin (registered in auth.ts) adds `removeUser` at runtime.
+  const adminApi = auth.api as typeof auth.api & {
+    removeUser: (opts: { body: { userId: string }; headers: Headers }) => Promise<{ success: boolean }>
+  }
+  const result = await adminApi.removeUser({
     body: { userId: user.id },
     headers: request.headers,
   })
 
-  if (!result) {
+  if (!result?.success) {
     return errorResponse('Failed to delete account', 500)
   }
 


### PR DESCRIPTION
## Summary

- **`/delete-account` public page** — Google Play-compliant account deletion URL. Works for logged-out users (sign-in prompt with redirect back) and logged-in users (typed `DELETE` confirmation, calls `DELETE /api/user/me`, signs out)
- **`DELETE /api/user/me` worker endpoint** — deletes R2 avatar/banner assets then removes the user record via Better Auth admin API
- **Settings → Account tab** — "Delete Account" button now links to `/delete-account` instead of being disabled
- **Admin → Users tab: Create User** — "Create User" button opens a modal with Name/Email/Password/Role fields, calls `authClient.admin.createUser`, prepends new user to list
- **Invite code hook bypass** — `worker/lib/auth.ts` invite code validation is now conditional so admin-created users don't need a code; self-registration still requires one

## Test plan

- [ ] `/delete-account` logged-out: shows sign-in prompt linking to `/login?redirect=/delete-account`
- [ ] After login redirect, shows logged-in state with confirmation input
- [ ] Typing `DELETE` enables the delete button; anything else keeps it disabled
- [ ] Submitting deletes account, signs out, redirects to `/login?deleted=1`
- [ ] Settings → Account → "Delete Account" links to `/delete-account` (not disabled)
- [ ] Admin → Users: "Create User" button visible in header
- [ ] Create User modal: fields validate (password ≥ 8 chars, name/email non-empty), button shows "Creating…" in flight
- [ ] Created user appears at top of list with correct role, no invite code required
- [ ] Duplicate email shows inline error without closing modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)