### PR TITLE
fix(player): fix video loading indicator and stream stability

### DIFF
--- a/src/components/player/FullScreenPlayer.tsx
+++ b/src/components/player/FullScreenPlayer.tsx
@@ -86,6 +86,7 @@ export function FullScreenPlayer() {
   const [animState, setAnimState] = useState<AnimState>("hidden");
   const [showTracklist, setShowTracklist] = useState(false);
   const [showControls, setShowControls] = useState(true);
+  const [isVideoBuffering, setIsVideoBuffering] = useState(false);
   const [upNextDetection, setUpNextDetection] = useState<Detection | null>(
     null
   );
@@ -181,10 +182,11 @@ export function FullScreenPlayer() {
     }
   }, [isVideoMode, videoStreamUrl, isLoadingVideo, loadVideoStream]);
 
-  // Set video src when stream URL is resolved — wait for loadeddata before syncing time
+  // Set video src when stream URL is resolved — wait for canplay before syncing time
   useEffect(() => {
     if (isVideoMode && videoStreamUrl && videoRef.current) {
       const video = videoRef.current;
+      setIsVideoBuffering(true);
 
       const onReady = () => {
         const audio = usePlayerStore.getState().audioElement;
@@ -194,14 +196,27 @@ export function FullScreenPlayer() {
         if (usePlayerStore.getState().isPlaying) {
           video.play().catch(() => {});
         }
-        video.removeEventListener("loadeddata", onReady);
+        setIsVideoBuffering(false);
+        video.removeEventListener("canplay", onReady);
       };
 
-      video.addEventListener("loadeddata", onReady);
+      const onError = () => {
+        setIsVideoBuffering(false);
+        // Clear cached URL so next attempt re-fetches a fresh signed URL
+        usePlayerStore.setState({ videoStreamUrl: null, isLoadingVideo: false });
+        video.removeEventListener("canplay", onReady);
+        video.removeEventListener("error", onError);
+      };
+
+      video.addEventListener("canplay", onReady);
+      video.addEventListener("error", onError);
       video.src = videoStreamUrl;
       video.load();
 
-      return () => video.removeEventListener("loadeddata", onReady);
+      return () => {
+        video.removeEventListener("canplay", onReady);
+        video.removeEventListener("error", onError);
+      };
     }
   }, [videoStreamUrl, isVideoMode]);
 
@@ -849,8 +864,12 @@ export function FullScreenPlayer() {
                     className="w-full h-full object-contain"
                     playsInline
                     muted
+                    onWaiting={() => setIsVideoBuffering(true)}
+                    onStalled={() => setIsVideoBuffering(true)}
+                    onPlaying={() => setIsVideoBuffering(false)}
+                    onCanPlay={() => setIsVideoBuffering(false)}
                   />
-                  {isLoadingVideo && (
+                  {(isLoadingVideo || isVideoBuffering) && (
                     <div
                       className="absolute inset-0 flex items-center justify-center"
                       style={{ background: "rgba(0,0,0,0.6)" }}

--- a/src/components/player/FullScreenPlayer.tsx
+++ b/src/components/player/FullScreenPlayer.tsx
@@ -68,6 +68,7 @@ export function FullScreenPlayer() {
     isFullScreen,
     isVideoMode,
     videoStreamUrl,
+    videoStreamExpiresAt,
     isLoadingVideo,
     isTheaterMode,
     setTheaterMode,
@@ -177,10 +178,11 @@ export function FullScreenPlayer() {
 
   // Load video stream when entering video mode
   useEffect(() => {
-    if (isVideoMode && !videoStreamUrl && !isLoadingVideo) {
+    const isExpiringSoon = videoStreamExpiresAt !== null && videoStreamExpiresAt - Date.now() < 60_000;
+    if (isVideoMode && (!videoStreamUrl || isExpiringSoon) && !isLoadingVideo) {
       loadVideoStream();
     }
-  }, [isVideoMode, videoStreamUrl, isLoadingVideo, loadVideoStream]);
+  }, [isVideoMode, videoStreamUrl, videoStreamExpiresAt, isLoadingVideo, loadVideoStream]);
 
   // Set video src when stream URL is resolved — wait for canplay before syncing time
   useEffect(() => {
@@ -203,7 +205,7 @@ export function FullScreenPlayer() {
       const onError = () => {
         setIsVideoBuffering(false);
         // Clear cached URL so next attempt re-fetches a fresh signed URL
-        usePlayerStore.setState({ videoStreamUrl: null, isLoadingVideo: false });
+        usePlayerStore.setState({ videoStreamUrl: null, videoStreamExpiresAt: null, isLoadingVideo: false });
         video.removeEventListener("canplay", onReady);
         video.removeEventListener("error", onError);
       };

--- a/src/stores/playerStore.ts
+++ b/src/stores/playerStore.ts
@@ -421,7 +421,7 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
       if (res.data?.url) {
         set({
           videoStreamUrl: res.data.url,
-          videoStreamExpiresAt: res.data.expires_at,
+          videoStreamExpiresAt: res.data.expires_at * 1000,
           isLoadingVideo: false,
         })
       } else {

--- a/src/stores/playerStore.ts
+++ b/src/stores/playerStore.ts
@@ -18,6 +18,7 @@ interface PlayerState {
   isVideoMode: boolean
   videoElement: HTMLVideoElement | null
   videoStreamUrl: string | null
+  videoStreamExpiresAt: number | null
   isLoadingVideo: boolean
 
   // Queue
@@ -94,6 +95,7 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
   isVideoMode: false,
   videoElement: null,
   videoStreamUrl: null,
+  videoStreamExpiresAt: null,
   isLoadingVideo: false,
   queue: [],
   queueIndex: -1,
@@ -143,6 +145,7 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
       currentDetections: [],
       isVideoMode: false,
       videoStreamUrl: null,
+      videoStreamExpiresAt: null,
     })
 
     // If no detections were passed (e.g. played from a card), fetch them in parallel
@@ -406,17 +409,21 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
   },
 
   loadVideoStream: async () => {
-    const { currentSet, videoStreamUrl } = get()
+    const { currentSet, videoStreamUrl, videoStreamExpiresAt } = get()
     if (!currentSet?.youtube_video_id) return
 
-    // Check if we already have a valid URL
-    if (videoStreamUrl) return
+    // Reuse cached URL only if it won't expire in the next 60 seconds
+    if (videoStreamUrl && videoStreamExpiresAt && videoStreamExpiresAt - Date.now() > 60_000) return
 
     set({ isLoadingVideo: true })
     try {
       const res = await fetchVideoStreamUrl(currentSet.id)
       if (res.data?.url) {
-        set({ videoStreamUrl: res.data.url, isLoadingVideo: false })
+        set({
+          videoStreamUrl: res.data.url,
+          videoStreamExpiresAt: res.data.expires_at,
+          isLoadingVideo: false,
+        })
       } else {
         set({ isLoadingVideo: false })
       }


### PR DESCRIPTION
## Summary

- **Loading indicator now covers the full buffering wait**: the spinner was disappearing as soon as the signed URL arrived, leaving a black screen while the video buffered. It now stays visible until `canplay` fires, and re-appears on mid-stream `waiting`/`stalled` events.
- **Video crash recovery**: added an `onError` handler on `<video>` that clears the cached stream URL so the player automatically re-fetches a fresh signed URL instead of looping on a broken one (previously caused audio-only fallback).
- **Signed URL expiry awareness**: `videoStreamExpiresAt` is now stored alongside the URL; the cache is only reused if the URL won't expire within 60 seconds, preventing failures on long sessions.

## Test plan

- [ ] Open a set with video, switch to VIDEO mode — spinner should remain visible until the video is ready to play (no black screen flash)
- [ ] Seek mid-stream — spinner should reappear briefly if the video needs to rebuffer
- [ ] Let a video session run for an extended time — verify video does not crash due to an expired URL
- [ ] Simulate a stream error (e.g. disconnect network briefly) — verify the player recovers and reloads rather than falling back to audio-only silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)