### PR TITLE
fix(auth): use Better Auth apiKey plugin for admin endpoints

### DIFF
--- a/worker/lib/auth.ts
+++ b/worker/lib/auth.ts
@@ -232,37 +232,6 @@ export async function requireAdmin(
   request: Request,
   env: Env
 ): Promise<{ user: { id: string; role: string; name: string; email: string } } | Response> {
-  // Allow extension/headless admin access via static API key
-  const apiKey = request.headers.get('X-Admin-API-Key')
-  if (apiKey) {
-    const validKey = (env as any).ADMIN_API_KEY as string | undefined
-    if (!validKey) {
-      return new Response(JSON.stringify({ error: 'ADMIN_API_KEY not configured', ok: false }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
-      })
-    }
-    // Use timing-safe comparison to prevent key enumeration via response time
-    const encoder = new TextEncoder()
-    const [incomingBuf, validBuf] = await Promise.all([
-      crypto.subtle.digest('SHA-256', encoder.encode(apiKey)),
-      crypto.subtle.digest('SHA-256', encoder.encode(validKey)),
-    ])
-    const incoming = new Uint8Array(incomingBuf)
-    const valid = new Uint8Array(validBuf)
-    let match = incoming.length === valid.length
-    for (let i = 0; i < incoming.length; i++) {
-      match = match && (incoming[i] === valid[i])
-    }
-    if (!match) {
-      return new Response(JSON.stringify({ error: 'Invalid API key', ok: false }), {
-        status: 401,
-        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
-      })
-    }
-    return { user: { id: 'api-key', role: 'admin', name: 'API Key', email: '' } }
-  }
-
   try {
     const auth = createAuth(env)
     const session = await auth.api.getSession({ headers: request.headers })

--- a/worker/lib/router.ts
+++ b/worker/lib/router.ts
@@ -116,7 +116,7 @@ export function corsHeaders(requestOrigin?: string | null): Headers {
 
   headers.set('Access-Control-Allow-Origin', origin)
   headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS')
-  headers.set('Access-Control-Allow-Headers', 'Content-Type, X-Anonymous-Id, Authorization, Range, x-api-key, X-Admin-API-Key')
+  headers.set('Access-Control-Allow-Headers', 'Content-Type, X-Anonymous-Id, Authorization, Range, x-api-key')
   headers.set('Access-Control-Expose-Headers', 'Content-Range, Content-Length, Accept-Ranges')
   headers.set('Access-Control-Allow-Credentials', 'true')
   headers.set('Access-Control-Max-Age', '86400')


### PR DESCRIPTION
## Summary
- Removes the custom `X-Admin-API-Key` static key path from `requireAdmin()`
- Admin endpoints now authenticate via `x-api-key: zeph_...` header, resolved by the Better Auth `apiKey` plugin (already configured with `enableSessionForAPIKeys: true`)
- Removes `X-Admin-API-Key` from CORS allowed headers since it's no longer used

## Motivation
`depth-cli` was sending `Authorization: Bearer zeph_...` which the backend never checked, causing 401s. Consolidating on the Better Auth `apiKey` plugin means all auth flows go through the same path.

## Test plan
- [ ] Run `depth-cli process --set-id <id>` and confirm the confirm step returns 200
- [ ] Confirm admin browser session still works for admin routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)