### PR TITLE
fix(auth): check x-api-key against ADMIN_API_KEY env var for CLI access

### DIFF
--- a/worker/lib/auth.ts
+++ b/worker/lib/auth.ts
@@ -232,37 +232,6 @@ export async function requireAdmin(
   request: Request,
   env: Env
 ): Promise<{ user: { id: string; role: string; name: string; email: string } } | Response> {
-  // Allow extension/headless admin access via static API key
-  const apiKey = request.headers.get('X-Admin-API-Key')
-  if (apiKey) {
-    const validKey = (env as any).ADMIN_API_KEY as string | undefined
-    if (!validKey) {
-      return new Response(JSON.stringify({ error: 'ADMIN_API_KEY not configured', ok: false }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
-      })
-    }
-    // Use timing-safe comparison to prevent key enumeration via response time
-    const encoder = new TextEncoder()
-    const [incomingBuf, validBuf] = await Promise.all([
-      crypto.subtle.digest('SHA-256', encoder.encode(apiKey)),
-      crypto.subtle.digest('SHA-256', encoder.encode(validKey)),
-    ])
-    const incoming = new Uint8Array(incomingBuf)
-    const valid = new Uint8Array(validBuf)
-    let match = incoming.length === valid.length
-    for (let i = 0; i < incoming.length; i++) {
-      match = match && (incoming[i] === valid[i])
-    }
-    if (!match) {
-      return new Response(JSON.stringify({ error: 'Invalid API key', ok: false }), {
-        status: 401,
-        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
-      })
-    }
-    return { user: { id: 'api-key', role: 'admin', name: 'API Key', email: '' } }
-  }
-
   try {
     const auth = createAuth(env)
     const session = await auth.api.getSession({ headers: request.headers })

--- a/worker/lib/auth.ts
+++ b/worker/lib/auth.ts
@@ -232,6 +232,33 @@ export async function requireAdmin(
   request: Request,
   env: Env
 ): Promise<{ user: { id: string; role: string; name: string; email: string } } | Response> {
+  const staticKey = request.headers.get('x-api-key')
+  if (staticKey) {
+    const validKey = (env as any).ADMIN_API_KEY as string | undefined
+    if (!validKey) {
+      return new Response(JSON.stringify({ error: 'ADMIN_API_KEY not configured', ok: false }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      })
+    }
+    const encoder = new TextEncoder()
+    const [incomingBuf, validBuf] = await Promise.all([
+      crypto.subtle.digest('SHA-256', encoder.encode(staticKey)),
+      crypto.subtle.digest('SHA-256', encoder.encode(validKey)),
+    ])
+    const incoming = new Uint8Array(incomingBuf)
+    const valid = new Uint8Array(validBuf)
+    let match = incoming.length === valid.length
+    for (let i = 0; i < incoming.length; i++) match = match && (incoming[i] === valid[i])
+    if (!match) {
+      return new Response(JSON.stringify({ error: 'Invalid API key', ok: false }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      })
+    }
+    return { user: { id: 'api-key', role: 'admin', name: 'API Key', email: '' } }
+  }
+
   try {
     const auth = createAuth(env)
     const session = await auth.api.getSession({ headers: request.headers })

--- a/worker/lib/router.ts
+++ b/worker/lib/router.ts
@@ -116,7 +116,7 @@ export function corsHeaders(requestOrigin?: string | null): Headers {
 
   headers.set('Access-Control-Allow-Origin', origin)
   headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS')
-  headers.set('Access-Control-Allow-Headers', 'Content-Type, X-Anonymous-Id, Authorization, Range, x-api-key, X-Admin-API-Key')
+  headers.set('Access-Control-Allow-Headers', 'Content-Type, X-Anonymous-Id, Authorization, Range, x-api-key')
   headers.set('Access-Control-Expose-Headers', 'Content-Range, Content-Length, Accept-Ranges')
   headers.set('Access-Control-Allow-Credentials', 'true')
   headers.set('Access-Control-Max-Age', '86400')


### PR DESCRIPTION
## Summary
- Restores static env-var key check in `requireAdmin()` using the `x-api-key` header
- Falls back to Better Auth session cookie for browser-based admin access

## Why not Better Auth apiKey plugin?
The `@better-auth/api-key` plugin requires keys to be created and stored in its `apikey` DB table. Arbitrary strings (like those in `depth-cli`'s config) won't resolve to a session — `getSession()` returns null and the request gets a 401.

Using `ADMIN_API_KEY` as a simple env var is the right approach for headless CLI access.

## Required
Set `ADMIN_API_KEY` in the worker environment (`.dev.vars` locally, `wrangler secret put ADMIN_API_KEY` for production) to the same value as `api_key` in `~/.depth-cli/config.toml`.

## Test plan
- [ ] `depth-cli process --set-id <id>` confirm step returns 200
- [ ] Browser admin session still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)