### PR TITLE
fix(auth): check x-api-key against ADMIN_API_KEY env var for CLI access

### DIFF
--- a/worker/lib/auth.ts
+++ b/worker/lib/auth.ts
@@ -232,6 +232,33 @@ export async function requireAdmin(
   request: Request,
   env: Env
 ): Promise<{ user: { id: string; role: string; name: string; email: string } } | Response> {
+  const staticKey = request.headers.get('x-api-key')
+  if (staticKey) {
+    const validKey = (env as any).ADMIN_API_KEY as string | undefined
+    if (!validKey) {
+      return new Response(JSON.stringify({ error: 'ADMIN_API_KEY not configured', ok: false }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      })
+    }
+    const encoder = new TextEncoder()
+    const [incomingBuf, validBuf] = await Promise.all([
+      crypto.subtle.digest('SHA-256', encoder.encode(staticKey)),
+      crypto.subtle.digest('SHA-256', encoder.encode(validKey)),
+    ])
+    const incoming = new Uint8Array(incomingBuf)
+    const valid = new Uint8Array(validBuf)
+    let match = incoming.length === valid.length
+    for (let i = 0; i < incoming.length; i++) match = match && (incoming[i] === valid[i])
+    if (!match) {
+      return new Response(JSON.stringify({ error: 'Invalid API key', ok: false }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      })
+    }
+    return { user: { id: 'api-key', role: 'admin', name: 'API Key', email: '' } }
+  }
+
   try {
     const auth = createAuth(env)
     const session = await auth.api.getSession({ headers: request.headers })


### PR DESCRIPTION
## Summary
- Restores static env-var key check in `requireAdmin()` using the `x-api-key` header
- Falls back to Better Auth session cookie for browser-based admin access

## Why not the Better Auth apiKey plugin?
The plugin requires keys to be created and stored in the `apikey` DB table — arbitrary strings won't work. A static `ADMIN_API_KEY` env var is the correct approach for headless CLI access.

## Required action
Set `ADMIN_API_KEY` in the worker environment to match the value of `api_key` in `~/.depth-cli/config.toml`:
- Local: add to `.dev.vars`
- Production: `wrangler secret put ADMIN_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)